### PR TITLE
use Calculus for derivative rules

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,1 @@
+Calculus

--- a/src/DualNumbers.jl
+++ b/src/DualNumbers.jl
@@ -1,6 +1,8 @@
 module DualNumbers
   importall Base
 
+  import Calculus
+
   include("dual.jl")
 
   export

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -128,23 +128,11 @@ function ^{T<:Dual}(z::T, w::T)
   dual(re, du)
 end
 
-exp(z::Dual) = dual(exp(real(z)), exp(real(z))*imag(z))
-log(z::Dual) = dual(log(real(z)), imag(z)/real(z))
-log2(z::Dual) = log(z)/oftype(real(z), 0.6931471805599453)
-log10(z::Dual) = log(z)/oftype(real(z), 2.302585092994046)
+for (funsym, exp) in Calculus.derivative_rules
+    @eval function $(funsym)(z::Dual)
+        xp = imag(z)
+        x = real(z)
+        Dual($(funsym)(x),$exp)
+    end
+end
 
-sin(z::Dual) = dual(sin(real(z)), cos(real(z))*imag(z))
-cos(z::Dual) = dual(cos(real(z)), -sin(real(z))*imag(z))
-tan(z::Dual) = dual(tan(real(z)), square(sec(real(z)))*imag(z))
-
-asin(z::Dual) = dual(asin(real(z)), imag(z)/sqrt(1-square(real(z))))
-acos(z::Dual) = dual(acos(real(z)), -imag(z)/sqrt(1-square(real(z))))
-atan(z::Dual) = dual(atan(real(z)), imag(z)/(1+square(real(z))))
-
-sinh(z::Dual) = dual(sinh(real(z)), cosh(real(z))*imag(z))
-cosh(z::Dual) = dual(cosh(real(z)), sinh(real(z))*imag(z))
-tanh(z::Dual) = dual(tanh(real(z)), 1-square(tanh(real(z)))*imag(z))
-
-asinh(z::Dual) = dual(asinh(real(z)), imag(z)/sqrt(real(z)*real(z)+1))
-acosh(z::Dual) = dual(acosh(real(z)), imag(z)/sqrt(real(z)*real(z)-1))
-atanh(z::Dual) = dual(atanh(real(z)), imag(z)/(1-real(z)*real(z)))

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -1,11 +1,12 @@
-## Calculation of f(2) and f'(2) of function f:R->R given by f(x)=x^3
-
 using DualNumbers
+using Base.Test
 
 x = dual(2, 1)
-f(x) = x^3
-y = f(x)
+y = x^3
 
-println("f(x) = x^3")
-println("f(2) = ", real(y))
-println("f'(2) = ", imag(y))
+@test_approx_eq real(y) 2.0^3
+@test_approx_eq imag(y) 3.0*2^2
+
+y = sin(x)+exp(x)
+@test_approx_eq real(y) sin(2)+exp(2)
+@test_approx_eq imag(y) cos(2)+exp(2)


### PR DESCRIPTION
We can simplify the code and improve functionality by taking the derivative rules from Calculus.jl. This is surprisingly easy to do.
