### PR TITLE
Add inf() for dual numbers

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -16,6 +16,7 @@ eps(z::Dual) = eps(real(z))
 eps{T}(::Type{Dual{T}}) = eps(T)
 one(z::Dual) = dual(one(real(z)))
 one{T}(::Type{Dual{T}}) = dual(one(T))
+inf{T}(::Type{Dual{T}}) = dual(inf(T))
 nan{T}(::Type{Dual{T}}) = nan(T)
 isnan(z::Dual) = isnan(real(z))
 


### PR DESCRIPTION
I'm not 100% certain this makes sense: it doesn't for complex numbers, but since in dual numbers the interpretation of the other term is really "epsilon," I wonder if it's more reasonable here.
