### PR TITLE
Implement mod(z::Dual, n::Number)

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -159,6 +159,8 @@ for f in [:^, :(NaNMath.pow)]
     end
 end
 
+mod(z::Dual, n::Number) = dual(mod(real(z), n), epsilon(z))
+
 # these two definitions are needed to fix ambiguity warnings
 ^(z::Dual, n::Integer) = dual(real(z)^n, epsilon(z)*n*real(z)^(n-1))
 ^(z::Dual, n::Rational) = dual(real(z)^n, epsilon(z)*n*real(z)^(n-1))

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -67,3 +67,6 @@ x = Dual(1.0,1.0)
 z(x, y) = x^2 + y
 @test z(1.0 + du, 1.0) == 2.0 + 2.0du
 @test z(1.0, 1.0 + du) == 2.0 + 1.0du
+
+@test real(mod(dual(15.23, 1), 10)) == 5.23
+@test epsilon(mod(dual(15.23, 1), 10)) == 1


### PR DESCRIPTION
I just made this work on the real part and leave the dual part as-is, because that's what I need in my application. I guess that should be OK at least in some aspect, since anywhere `mod` is applicable, periodicity is implied which should make the derivative the same, but if you have better ideas, let me know :)