### PR TITLE
deprecate lowercase constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
   - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ supported.
 
 
 The following functions are specific to dual numbers:
-* `dual`,
-* `dual128`,
-* `dual64`,
 * `epsilon`,
 * `isdual`,
 * `dual_show`,
@@ -70,9 +67,9 @@ Then make the package available via
 
     using DualNumbers
 
-Use the `dual()` function to define the dual number `2+1*du`:
+Use the `Dual()` constructor to define the dual number `2+1*du`:
 
-    x = dual(2, 1)
+    x = Dual(2, 1)
 
 Define a function that will be differentiated, say
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.3
+julia 0.4
 Calculus
 NaNMath
-Compat

--- a/src/DualNumbers.jl
+++ b/src/DualNumbers.jl
@@ -1,9 +1,8 @@
-isdefined(Base, :__precompile__) && __precompile__()
+__precompile__()
 
 module DualNumbers
   importall Base
 
-  using Compat
   import NaNMath
   import Calculus
 
@@ -15,9 +14,6 @@ module DualNumbers
     Dual128,
     Dual64,
     DualPair,
-    dual,
-    dual128,
-    dual64,
     isdual,
     dual_show,
     epsilon,

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -1,7 +1,7 @@
 using DualNumbers
 using Base.Test
 
-x = dual(2, 1)
+x = Dual(2, 1)
 y = x^3
 
 @test_approx_eq real(y) 2.0^3
@@ -21,15 +21,15 @@ y = abs(-x)
 @test_approx_eq real(y) 2.0
 @test_approx_eq epsilon(y) 1.0
 
-@test isequal(1.0,dual(1.0))
+@test isequal(1.0,Dual(1.0))
 
 y = 1/x
 @test_approx_eq real(y) 1/2
 @test_approx_eq epsilon(y) -1/2^2
 
 Q = [1.0 0.1; 0.1 1.0]
-x = dual([1.0,2.0])
-x[1] = dual(1.0,1.0)
+x = Dual([1.0,2.0])
+x[1] = Dual(1.0,1.0)
 y = (1/2)*dot(x,Q*x)
 @test_approx_eq real(y) 2.7
 @test_approx_eq epsilon(y) 1.2
@@ -68,5 +68,5 @@ z(x, y) = x^2 + y
 @test z(1.0 + du, 1.0) == 2.0 + 2.0du
 @test z(1.0, 1.0 + du) == 2.0 + 1.0du
 
-@test real(mod(dual(15.23, 1), 10)) == 5.23
-@test epsilon(mod(dual(15.23, 1), 10)) == 1
+@test real(mod(Dual(15.23, 1), 10)) == 5.23
+@test epsilon(mod(Dual(15.23, 1), 10)) == 1


### PR DESCRIPTION
drops support for 0.3.
The package fell a bit behind in following the Julia convention of deprecating ``int`` for ``Int`` etc. Only question is what we should do for the vectorized versions. ``float([1,2,3])`` is still around, but ``int([1.0,2.0,3.0])`` is not. Is ``Dual([1.0,2.0,3.0])`` okay for creating an array of dual numbers, or should we keep ``dual`` for the vectorized case?