### PR TITLE
Add support for Dual{Complex}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
   - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -2,22 +2,23 @@
 
 ### Scope of DualNumbers.jl
 
-The `DualNumbers` package defines the `Dual` type to represent dual numbers and 
-supports standard mathematical operations on them. Conversions and promotions 
-are defined to allow performing operations on combinations of dual numbers with 
+The `DualNumbers` package defines the `Dual` type to represent dual numbers and
+supports standard mathematical operations on them. Conversions and promotions
+are defined to allow performing operations on combinations of dual numbers with
 predefined Julia numeric types.
 
-Dual numbers extend the real numbers, similar to complex numbers. They adjoin a 
-new element `ϵ` such that `ϵ*ϵ=0`, in a similar way that complex numbers 
-adjoin the imaginary unit `i` with the property `i*i=-1`. So the typical 
-representation of a dual number takes the form `x+y*ϵ`, where `x` and `y` are 
-real numbers.
+Dual numbers extend the real numbers, similar to complex numbers. They adjoin a
+new element `ɛ` such that `ɛ*ɛ=0`, in a similar way that complex numbers
+adjoin the imaginary unit `i` with the property `i*i=-1`. So the typical
+representation of a dual number takes the form `x+y*ɛ`, where `x` and `y` are
+real numbers. Duality can further extend complex numbers by adjoining one new
+element to each of the real and imaginary parts.
 
-Apart from their mathematical role in algebraic and differential geometry (they 
-are mainly interpreted as angles between lines), they also find applications in 
-physics (the real part of a dual represents the bosonic direction, while the 
-epsilon part represents the fermionic direction), in screw theory, in motor 
-and spatial vector algebra, and in computer science due to its relation with the 
+Apart from their mathematical role in algebraic and differential geometry (they
+are mainly interpreted as angles between lines), they also find applications in
+physics (the real part of a dual represents the bosonic direction, while the
+epsilon part represents the fermionic direction), in screw theory, in motor
+and spatial vector algebra, and in computer science due to its relation with the
 forward mode of automatic differentiation.
 
 The [ForwardDiff](https://github.com/scidom/ForwardDiff.jl) package implements forward mode automatic differentiation in Julia using several approaches. One
@@ -27,15 +28,15 @@ dual numbers in Julia.
 
 ## Supported functions
 
-We aim for complete support for `Dual` types for numerical functions within Julia's 
+We aim for complete support for `Dual` types for numerical functions within Julia's
 `Base`. Currently, basic mathematical operations and trigonometric functions are
 supported.
 
 
 The following functions are specific to dual numbers:
 * `dual`,
-* `dual128`,
-* `dual64`,
+* `realpart`,
+* `dualpart`,
 * `epsilon`,
 * `isdual`,
 * `dual_show`,
@@ -43,49 +44,55 @@ The following functions are specific to dual numbers:
 * `absdual`,
 * `abs2dual`.
 
+The dual number `f(a+bɛ)` is defined by the limit:
+
+    f(a+bɛ) := f(a) + lim_{h→0} (f(a + bɛh) - f(a))/h .
+
+For complex differentiable functions, this is equivalent to differentiation:
+
+    f(a+bɛ) := f(a) + b f'(a) ɛ.
+
+For functions that are not complex differentiable, the dual part returns the limit
+and can be identified with a directional derivative in `R²`.
+
 In some cases the mathematical definition of functions of ``Dual`` numbers
 is in conflict with their use as a drop-in replacement for calculating
-numerical derivatives, for example, ``conj``, ``abs`` and ``abs2``. In these
-cases, we choose to follow the rule ``f(x::Dual) = Dual(f(real(x)),epsilon(x)*f'(real(x)))``,
-where ``f'`` is the derivative of ``f``. The mathematical definitions are
-available using the functions with the suffix ``dual``.
-Similarly, comparison operators ``<``, ``>``, and ``==`` are overloaded to compare only real
+numerical derivatives, for example, ``conj``, ``abs`` and ``abs2``. The mathematical
+definitions are available using the functions with the suffix ``dual``.
+Similarly, comparison operators ``<``, ``>``, and ``==`` are overloaded to compare only value
 components.
-
-
-
 
 ### A walk-through example
 
-The example below demonstrates basic usage of dual numbers by employing them to 
-perform automatic differentiation. The code for this example can be found in 
+The example below demonstrates basic usage of dual numbers by employing them to
+perform automatic differentiation. The code for this example can be found in
 `test/automatic_differentiation_test.jl`.
 
 First install the package by using the Julia package manager:
 
     Pkg.update()
     Pkg.add("DualNumbers")
-    
+
 Then make the package available via
 
     using DualNumbers
 
-Use the `dual()` function to define the dual number `2+1*du`:
+Use the `Dual()` constructor to define the dual number `2+1*ɛ`:
 
-    x = dual(2, 1)
+    x = Dual(2, 1)
 
 Define a function that will be differentiated, say
 
     f(x) = x^3
 
-Perform automatic differentiation by passing the dual number `x` as argument to 
+Perform automatic differentiation by passing the dual number `x` as argument to
 `f`:
 
     y = f(x)
 
-Use the functions `real()` and `epsilon()` to get the real and imaginary (dual) 
+Use the functions `realpart` and `dualpart` to get the concrete and dual
 parts of `x`, respectively:
 
     println("f(x) = x^3")
-    println("f(2) = ", real(y))
-    println("f'(2) = ", epsilon(y))
+    println("f(2) = ", realpart(y))
+    println("f'(2) = ", dualpart(y))

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.3
+julia 0.4
 Calculus
 NaNMath
-Compat

--- a/src/DualNumbers.jl
+++ b/src/DualNumbers.jl
@@ -1,28 +1,36 @@
-isdefined(Base, :__precompile__) && __precompile__()
+__precompile__()
 
 module DualNumbers
   importall Base
 
-  using Compat
   import NaNMath
   import Calculus
 
   include("dual.jl")
   include("dual_n.jl")
 
+  Base.@deprecate_binding du ɛ
+  @deprecate inf{T}(::Type{Dual{T}}) convert(Dual{T}, Inf)
+  @deprecate nan{T}(::Type{Dual{T}}) convert(Dual{T}, NaN)
+  @deprecate real{T<:Real}(z::Dual{T}) realpart(z)
+
   export
     Dual,
     Dual128,
     Dual64,
-    DualPair,
+    Dual32,
+    DualComplex256,
+    DualComplex128,
+    DualComplex64,
     dual,
-    dual128,
-    dual64,
+    epsilon,
+    realpart,
+    dualpart,
     isdual,
     dual_show,
-    epsilon,
     conjdual,
     absdual,
     abs2dual,
-    du
+    ɛ,
+    imɛ
 end

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -1,43 +1,43 @@
-using DualNumbers
-using Base.Test
+using DualNumbers, Base.Test
+import DualNumbers: value
 
-x = dual(2, 1)
+x = Dual(2, 1)
 y = x^3
 
-@test_approx_eq real(y) 2.0^3
+@test_approx_eq value(y) 2.0^3
 @test_approx_eq epsilon(y) 3.0*2^2
 
 y = x^3.0
 
-@test_approx_eq real(y) 2.0^3
+@test_approx_eq value(y) 2.0^3
 @test_approx_eq epsilon(y) 3.0*2^2
 
 y = sin(x)+exp(x)
-@test_approx_eq real(y) sin(2)+exp(2)
+@test_approx_eq value(y) sin(2)+exp(2)
 @test_approx_eq epsilon(y) cos(2)+exp(2)
 
 @test x > 1
 y = abs(-x)
-@test_approx_eq real(y) 2.0
+@test_approx_eq value(y) 2.0
 @test_approx_eq epsilon(y) 1.0
 
-@test isequal(1.0,dual(1.0))
+@test isequal(1.0,Dual(1.0))
 
 y = 1/x
-@test_approx_eq real(y) 1/2
+@test_approx_eq value(y) 1/2
 @test_approx_eq epsilon(y) -1/2^2
 
 Q = [1.0 0.1; 0.1 1.0]
 x = dual([1.0,2.0])
-x[1] = dual(1.0,1.0)
+x[1] = Dual(1.0,1.0)
 y = (1/2)*dot(x,Q*x)
-@test_approx_eq real(y) 2.7
+@test_approx_eq value(y) 2.7
 @test_approx_eq epsilon(y) 1.2
 
 function squareroot(x)
     it = x
     while abs(it*it - x) > 1e-13
-        it = it - (it*it-x)/(2it)
+        it = (it+x/it)/2
     end
     return it
 end
@@ -61,12 +61,70 @@ x = Dual(1.0,1.0)
 @test convert(Float64, Dual(10.0,0.0)) == 10.0
 @test convert(Dual{Int}, Dual(10.0,0.0)) == Dual(10,0)
 
-# tests for constant du
-@test epsilon(1.0 + du) == 1.0
-@test epsilon(1.0 + 0.0du) == 0.0
-z(x, y) = x^2 + y
-@test z(1.0 + du, 1.0) == 2.0 + 2.0du
-@test z(1.0, 1.0 + du) == 2.0 + 1.0du
+# test Dual{Complex}
 
-@test real(mod(dual(15.23, 1), 10)) == 5.23
-@test epsilon(mod(dual(15.23, 1), 10)) == 1
+z = Dual(1.0+1.0im,1.0)
+f = exp(z)
+@test value(f) == exp(value(z))
+@test epsilon(f) == epsilon(z)*exp(value(z))
+
+g = sinpi(z)
+@test value(g) == sinpi(value(z))
+@test epsilon(g) == epsilon(z)*cospi(value(z))*π
+
+h = z^4
+@test value(h) == value(z)^4
+@test epsilon(h) == 4epsilon(z)*value(z)^3
+
+a = abs2(z)
+@test value(a) == abs2(value(z))
+@test epsilon(a) == conj(epsilon(z))*value(z)+conj(value(z))*epsilon(z)
+
+l = log(z)
+@test value(l) == log(value(z))
+@test epsilon(l) == epsilon(z)/value(z)
+
+s = sign(z)
+@test value(s) == value(z)/abs(value(z))
+
+a = angle(z)
+@test value(a) == angle(value(z))
+
+@test angle(Dual(0.0+im,0.0+im)) == π/2
+
+#
+# Tests limit definition. Let z = a + b ɛ, where a and b ∈ C.
+#
+# The dual of |z| is lim_{h→0} (|a + bɛh| - |a|)/h
+#
+# and it depends on the direction (i.e. the complex value of epsilon(z)).
+#
+
+z = Dual(1.0+1.0im,1.0)
+@test abs(z) ≡ sqrt(2) + 1/sqrt(2)*ɛ
+z = Dual(1.0+1.0im,cis(π/4))
+@test abs(z) ≡ sqrt(2) + 2/sqrt(2)^2*ɛ
+z = Dual(1.0+1.0im,cis(π/2))
+@test abs(z) ≡ sqrt(2) + 1/sqrt(2)*ɛ
+
+# tests vectorized methods
+zv = dual(collect(1.0:10.0),ones(10))
+
+f = exp(zv)
+@test all(value(f) .== exp(value(zv)))
+@test all(epsilon(f) .== epsilon(zv).*exp(value(zv)))
+
+# tests norms and inequalities
+@test norm(f,Inf) ≤ norm(f) ≤ norm(f,1)
+
+# tests for constant ɛ
+@test epsilon(1.0 + ɛ) == 1.0
+@test epsilon(1.0 + 0.0ɛ) == 0.0
+test(x, y) = x^2 + y
+@test test(1.0 + ɛ, 1.0) == 2.0 + 2.0ɛ
+@test test(1.0, 1.0 + ɛ) == 2.0 + 1.0ɛ
+
+@test ɛ*im == Dual(Complex(false,false),Complex(false,true))
+
+@test value(mod(Dual(15.23, 1), 10)) == 5.23
+@test epsilon(mod(Dual(15.23, 1), 10)) == 1


### PR DESCRIPTION
Dear dualists (duellers?)

We would like to use DualNumbers in ApproxFun and dependent packages such as SingularIntegralEquations as a requirement. In ApproxFun, we create expansions of functions in numerous spectral bases (Chebyshev, Fourier, Legendre, Jacobi, etc...) and solve ordinary and partial differential equations in these bases as well.

One particular use of dual numbers will be in automatic differentiation to compute normal derivatives of incident waves to solve elliptic PDEs like the Helmholtz equation with Neumann boundary conditions in SingularIntegralEquations.

To make the transition possible, DualNumbers must be extended to work on Complex data types as well. This required a minor rewrite, and for the most part an improvement.

I would be happy to see this merged, though I can be patient given dependencies on DualNumbers that would break.

If merged, this would close #13, #23 (as a patch), and #24.