### PR TITLE
Support floor, ceil, trunc, and round

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -183,6 +183,11 @@ hash(z::Dual) = (x = hash(value(z)); epsilon(z)==0 ? x : bitmix(x,hash(epsilon(z
 float{T<:AbstractFloat}(z::Union{Dual{T},Dual{Complex{T}}})=z
 complex{T<:Real}(z::Dual{Complex{T}})=z
 
+floor{T<:Real}(::Type{T}, z::Dual) = floor(T, value(z))
+ceil{ T<:Real}(::Type{T}, z::Dual) = ceil( T, value(z))
+trunc{T<:Real}(::Type{T}, z::Dual) = trunc(T, value(z))
+round{T<:Real}(::Type{T}, z::Dual) = round(T, value(z))
+
 for op in (:real,:imag,:conj,:float,:complex)
     @eval begin
         $op(z::Dual) = Dual($op(value(z)),$op(epsilon(z)))

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -61,6 +61,12 @@ x = Dual(1.0,1.0)
 @test convert(Float64, Dual(10.0,0.0)) == 10.0
 @test convert(Dual{Int}, Dual(10.0,0.0)) == Dual(10,0)
 
+x = Dual(1.2,1.0)
+@test floor(Int, x) == 1
+@test ceil(Int, x)  == 2
+@test trunc(Int, x) == 1
+@test round(Int, x) == 1
+
 # test Dual{Complex}
 
 z = Dual(1.0+1.0im,1.0)


### PR DESCRIPTION
This is the analog of https://github.com/JuliaDiff/ForwardDiff.jl/pull/84.

It's probably the best approach to get the tests for Interpolations working again (deprecation of `real(::Dual)` caused an `@inferred` test to fail, I guess deprecation warnings break inference?). So, once merged, a new tagged release pronto would be appreciated.

CC @tlycken, @spencerlyon2 (to the two of you: I have the corresponding PR for Interpolations ready to go, will wait until this is merged and tagged to submit, so Travis doesn't complain.)
