### PR TITLE
fix use of global variables

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -41,8 +41,8 @@ dual(z::Dual) = z
 @vectorize_1arg Dual value
 @vectorize_1arg Dual epsilon
 
-realpart = value
-dualpart = epsilon
+const realpart = value
+const dualpart = epsilon
 
 isnan(z::Dual) = isnan(value(z))
 isinf(z::Dual) = isinf(value(z))


### PR DESCRIPTION
global variables bad for performance etc

Fixes:

```jl
julia> @code_warntype foo()
Variables:
  d::DualNumbers.Dual{Float64}
  a::Any

Body:
  begin  # none, line 2:
      a = 0.0 # none, line 3:
      d = $(Expr(:new, DualNumbers.Dual{Float64}, 1.0, 1.0)) # none, line 5:
      a = a::Float64 + (Main.dualpart)(d::DualNumbers.Dual{Float64})::Any::Any # none, line 6:
      return a
  end::Any
```
