### PR TITLE
Remove real deprecation

### DIFF
--- a/src/DualNumbers.jl
+++ b/src/DualNumbers.jl
@@ -12,7 +12,6 @@ module DualNumbers
   Base.@deprecate_binding du ɛ
   @deprecate inf{T}(::Type{Dual{T}}) convert(Dual{T}, Inf)
   @deprecate nan{T}(::Type{Dual{T}}) convert(Dual{T}, NaN)
-  @deprecate real{T<:Real}(z::Dual{T}) realpart(z)
 
   export
     Dual,

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -195,8 +195,10 @@ for op in (:real,:imag,:conj,:float,:complex)
 end
 
 abs(z::Dual) = sqrt(abs2(z))
-abs2(z::Dual) = (ζ = conj(z)*z; Dual(real(value(ζ)),real(epsilon(ζ)))) # real(conj(z)*z) when real{T<:Real}(z::Dual{T})=z
-abs{T<:Real}(z::Dual{T})  = z ≥ 0 ? z : -z
+abs2(z::Dual) = real(conj(z)*z)
+
+real{T<:Real}(z::Dual{T}) = z
+abs{T<:Real}(z::Dual{T}) = z ≥ 0 ? z : -z
 
 angle{T<:Real}(z::Dual{T}) = z ≥ 0 ? zero(z) : one(z)*π
 angle{T<:Real}(z::Dual{Complex{T}}) = z == 0 ? (imag(epsilon(z)) == 0 ? Dual(zero(T),zero(T)) : Dual(zero(T),convert(T, Inf))) : real(log(sign(z))/im)


### PR DESCRIPTION
This allows `real` to be the mathematical function `Re(z)` rather than a deprecated accessor. This PR is a follow-up to the agreed definitions in #29. cc: @mlubin, @jrevels, @goretkin, @dlfivefifty