### PR TITLE
Fix depwarn on 0.6 due to vectorized functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
+Compat 0.9.1
 Calculus
 NaNMath

--- a/src/DualNumbers.jl
+++ b/src/DualNumbers.jl
@@ -5,6 +5,7 @@ module DualNumbers
 
   import NaNMath
   import Calculus
+  using Compat
 
   include("dual.jl")
   include("dual_n.jl")

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -35,11 +35,11 @@ dual(x::ReComp, y::ReComp) = Dual(x, y)
 dual(x::ReComp) = Dual(x)
 dual(z::Dual) = z
 
-@vectorize_1arg ReComp dual
-@vectorize_2arg ReComp dual
-@vectorize_1arg Dual dual
-@vectorize_1arg Dual value
-@vectorize_1arg Dual epsilon
+Compat.@dep_vectorize_1arg ReComp dual
+Compat.@dep_vectorize_2arg ReComp dual
+Compat.@dep_vectorize_1arg Dual dual
+Compat.@dep_vectorize_1arg Dual value
+Compat.@dep_vectorize_1arg Dual epsilon
 
 const realpart = value
 const dualpart = epsilon

--- a/src/dual_n.jl
+++ b/src/dual_n.jl
@@ -132,7 +132,7 @@ function ^(z::Dual4, n::Integer)
     zn1 = n*real(z)^(n-1)
     Dual4(real(z)^n, epsilon1(z)*zn1, epsilon2(z)*zn1, epsilon3(z)*zn1, epsilon4(z)*zn1)
 end
-^(z::Dual4, n::Rational) = invoke(^, (Dual4,Real), z,n)
+^(z::Dual4, n::Rational) = invoke(^, Tuple{Dual4,Real}, z,n)
 
 function ^(z::Dual4, n::Real)
     zn1 = n*real(z)^(n-1)
@@ -144,7 +144,7 @@ function NaNMath.pow(z::Dual4, n::Real)
     Dual4(NaNMath.pow(real(z),n), epsilon1(z)*powval, epsilon2(z)*powval, epsilon3(z)*powval, epsilon4(z)*powval)
 end
 function NaNMath.pow(z::Real, w::Dual4)
-    logval = NaNMath.pow(z,real(w))*log(z) 
+    logval = NaNMath.pow(z,real(w))*log(z)
     Dual4(NaNMath.pow(z,real(w)), epsilon1(w)*logval, epsilon2(w)*logval, epsilon3(w)*logval, epsilon4(w)*logval)
 end
 

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -1,5 +1,7 @@
 using DualNumbers, Base.Test
 import DualNumbers: value
+import NaNMath
+using Compat
 
 x = Dual(2, 1)
 y = x^3
@@ -28,7 +30,7 @@ y = 1/x
 @test_approx_eq epsilon(y) -1/2^2
 
 Q = [1.0 0.1; 0.1 1.0]
-x = dual([1.0,2.0])
+x = @compat dual.([1.0,2.0])
 x[1] = Dual(1.0,1.0)
 y = (1/2)*dot(x,Q*x)
 @test_approx_eq value(y) 2.7
@@ -114,11 +116,11 @@ z = Dual(1.0+1.0im,cis(π/2))
 @test abs(z) ≡ sqrt(2) + 1/sqrt(2)*ɛ
 
 # tests vectorized methods
-zv = dual(collect(1.0:10.0),ones(10))
+const zv = @compat dual.(collect(1.0:10.0), ones(10))
 
-f = exp(zv)
-@test all(value(f) .== exp(value(zv)))
-@test all(epsilon(f) .== epsilon(zv).*exp(value(zv)))
+f = @compat exp.(zv)
+@test all(@compat value.(f) .== exp.(value.(zv)))
+@test all(@compat epsilon.(f) .== epsilon.(zv) .* exp.(value.(zv)))
 
 # tests norms and inequalities
 @test norm(f,Inf) ≤ norm(f) ≤ norm(f,1)

--- a/test/dual_n.jl
+++ b/test/dual_n.jl
@@ -1,5 +1,6 @@
 using DualNumbers
 import DualNumbers: Dual4, real, epsilon1, epsilon2, epsilon3, epsilon4
+import NaNMath
 using Base.Test
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,10 @@
+#
+
+# wrap in individual modules to avoid name conflicts.
+module TestAutomaticDifferentiation
 include("automatic_differentiation_test.jl")
+end
+
+module TestDual
 include("dual_n.jl")
+end


### PR DESCRIPTION
Also use tuple type instead of tuples (Ref https://github.com/JuliaLang/julia/pull/18444 and it's easier to infer in general)