### PR TITLE
Support checkindex

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -293,3 +293,7 @@ cis(z::Dual) = (cisval = cis(value(z)); Dual(cisval, im*epsilon(z)*cisval))
 ## TODO: should be generated in Calculus
 sinpi(z::Dual) = Dual(sinpi(value(z)),epsilon(z)*cospi(value(z))*π)
 cospi(z::Dual) = Dual(cospi(value(z)),-epsilon(z)*sinpi(value(z))*π)
+
+if VERSION >= v"0.5.0-dev+5429"
+    Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Dual) = checkindex(Bool, inds, value(i))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,8 @@
-#
+using DualNumbers, Base.Test
+
+if VERSION >= v"0.5.0-dev+5429"
+    @test checkindex(Bool, 1:3, dual(2))
+end
 
 # wrap in individual modules to avoid name conflicts.
 module TestAutomaticDifferentiation


### PR DESCRIPTION
This allows one to use DualNumbers to compute gradients of array types that allow then for indexing (e.g., Interpolations).
