### PR TITLE
Transfer DualNumbers implementation from ForwardDiff

### DIFF
--- a/src/DualNumbers.jl
+++ b/src/DualNumbers.jl
@@ -7,29 +7,20 @@ module DualNumbers
   import Calculus
   using Compat
 
+  const NANSAFE_MODE_ENABLED = false                                              
+                                                                                  
+  const IS_MULTITHREADED_JULIA = VERSION >= v"0.5.0-dev+923" 
+  const AUTO_DEFINED_UNARY_FUNCS = map(first, Calculus.symbolic_derivatives_1arg())
+
+  const NANMATH_FUNCS = (:sin, :cos, :tan, :asin, :acos, :acosh,                  
+                         :atanh, :log, :log2, :log10, :lgamma, :log1p)
+
+  include("partials.jl")
   include("dual.jl")
 
-  Base.@deprecate_binding du ɛ
-  @deprecate inf{T}(::Type{Dual{T}}) convert(Dual{T}, Inf)
-  @deprecate nan{T}(::Type{Dual{T}}) convert(Dual{T}, NaN)
+  export Dual,
+  value,
+  partials
 
-  export
-    Dual,
-    Dual128,
-    Dual64,
-    Dual32,
-    DualComplex256,
-    DualComplex128,
-    DualComplex64,
-    dual,
-    epsilon,
-    realpart,
-    dualpart,
-    isdual,
-    dual_show,
-    conjdual,
-    absdual,
-    abs2dual,
-    ɛ,
-    imɛ
+
 end

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -1,261 +1,293 @@
-typealias ReComp Union{Real,Complex}
+const ExternalReal = Union{subtypes(Real)...}
 
-immutable Dual{T<:ReComp} <: Number
+########
+# Dual #
+########
+
+immutable Dual{N,T<:Real} <: Real
     value::T
-    epsilon::T
-end
-Dual{S<:ReComp,T<:ReComp}(x::S, y::T) = Dual(promote(x,y)...)
-Dual(x::ReComp) = Dual(x, zero(x))
-
-const ɛ = Dual(false, true)
-const imɛ = Dual(Complex(false, false), Complex(false, true))
-
-typealias Dual128 Dual{Float64}
-typealias Dual64  Dual{Float32}
-typealias Dual32  Dual{Float16}
-typealias DualComplex256 Dual{Complex128}
-typealias DualComplex128 Dual{Complex64}
-typealias DualComplex64  Dual{Complex32}
-
-convert{T<:ReComp}(::Type{Dual{T}}, z::Dual{T}) = z
-convert{T<:ReComp}(::Type{Dual{T}}, z::Dual) = Dual{T}(convert(T, value(z)), convert(T, epsilon(z)))
-convert{T<:ReComp}(::Type{Dual{T}}, x::Number) = Dual{T}(convert(T, x), convert(T, 0))
-convert{T<:ReComp}(::Type{T}, z::Dual) = (epsilon(z)==0 ? convert(T, value(z)) : throw(InexactError()))
-
-promote_rule{T<:ReComp, S<:ReComp}(::Type{Dual{T}}, ::Type{Dual{S}}) = Dual{promote_type(T, S)}
-promote_rule{T<:ReComp, S<:ReComp}(::Type{Dual{T}}, ::Type{S}) = Dual{promote_type(T, S)}
-promote_rule{T<:ReComp}(::Type{Dual{T}}, ::Type{T}) = Dual{T}
-
-widen{T}(::Type{Dual{T}}) = Dual{widen(T)}
-
-value(z::Dual) = z.value
-epsilon(z::Dual) = z.epsilon
-
-dual(x::ReComp, y::ReComp) = Dual(x, y)
-dual(x::ReComp) = Dual(x)
-dual(z::Dual) = z
-
-Compat.@dep_vectorize_1arg ReComp dual
-Compat.@dep_vectorize_2arg ReComp dual
-Compat.@dep_vectorize_1arg Dual dual
-Compat.@dep_vectorize_1arg Dual value
-Compat.@dep_vectorize_1arg Dual epsilon
-
-const realpart = value
-const dualpart = epsilon
-
-isnan(z::Dual) = isnan(value(z))
-isinf(z::Dual) = isinf(value(z))
-isfinite(z::Dual) = isfinite(value(z))
-isdual(x::Dual) = true
-isdual(x::Number) = false
-eps(z::Dual) = eps(value(z))
-eps{T}(::Type{Dual{T}}) = eps(T)
-
-function dual_show{T<:Real}(io::IO, z::Dual{T}, compact::Bool)
-    x, y = value(z), epsilon(z)
-    if isnan(x) || isfinite(y)
-        compact ? showcompact(io,x) : show(io,x)
-        if signbit(y)==1 && !isnan(y)
-            y = -y
-            print(io, compact ? "-" : " - ")
-        else
-            print(io, compact ? "+" : " + ")
-        end
-        compact ? showcompact(io, y) : show(io, y)
-        printtimes(io, y)
-        print(io, "ɛ")
-    else
-        print(io, "Dual{",T,"}(", x, ",", y, ")")
-    end
+    partials::Partials{N,T}
 end
 
-function dual_show{T<:Complex}(io::IO, z::Dual{T}, compact::Bool)
-    x, y = value(z), epsilon(z)
-    xr, xi = reim(x)
-    yr, yi = reim(y)
-    if isnan(x) || isfinite(y)
-        compact ? showcompact(io,x) : show(io,x)
-        if signbit(yr)==1 && !isnan(y)
-            yr = -yr
-            print(io, " - ")
-        else
-            print(io, " + ")
-        end
-        if compact
-            if signbit(yi)==1 && !isnan(y)
-                yi = -yi
-                showcompact(io, yr)
-                printtimes(io, yr)
-                print(io, "ɛ-")
-                showcompact(io, yi)
-            else
-                showcompact(io, yr)
-                print(io, "ɛ+")
-                showcompact(io, yi)
+################
+# Constructors #
+################
+
+Dual{N,T}(value::T, partials::Partials{N,T}) = Dual{N,T}(value, partials)
+
+function Dual{N,A,B}(value::A, partials::Partials{N,B})
+    T = promote_type(A, B)
+    return Dual(convert(T, value), convert(Partials{N,T}, partials))
+end
+
+Dual(value::Real, partials::Tuple) = Dual(value, Partials(partials))
+Dual(value::Real, partials::Tuple{}) = Dual(value, Partials{0,typeof(value)}(partials))
+Dual(value::Real, partials::Real...) = Dual(value, partials)
+
+##############################
+# Utility/Accessor Functions #
+##############################
+
+@inline value(x::Real) = x
+@inline value(n::Dual) = n.value
+
+@inline partials(x::Real) = Partials{0,typeof(x)}(tuple())
+@inline partials(n::Dual) = n.partials
+@inline partials(x::Real, i...) = zero(x)
+@inline partials(n::Dual, i) = n.partials[i]
+@inline partials(n::Dual, i, j) = partials(n, i).partials[j]
+@inline partials(n::Dual, i, j, k...) = partials(partials(n, i, j), k...)
+
+@inline npartials{N}(::Dual{N}) = N
+@inline npartials{N,T}(::Type{Dual{N,T}}) = N
+
+@inline degree{T}(::T) = degree(T)
+@inline degree{T}(::Type{T}) = 0
+degree{N,T}(::Type{Dual{N,T}}) = 1 + degree(T)
+
+@inline valtype{T}(::T) = T
+@inline valtype{T}(::Type{T}) = T
+@inline valtype{N,T}(::Dual{N,T}) = T
+@inline valtype{N,T}(::Type{Dual{N,T}}) = T
+
+#####################
+# Generic Functions #
+#####################
+
+macro ambiguous(ex)
+    def = ex.head == :macrocall ? ex.args[2] : ex
+    sig = def.args[1]
+    body = def.args[2]
+    f = isa(sig.args[1], Expr) && sig.args[1].head == :curly ? sig.args[1].args[1] : sig.args[1]
+    a, b = sig.args[2].args[1], sig.args[3].args[1]
+    Ta, Tb = sig.args[2].args[2], sig.args[3].args[2]
+    if isa(a, Symbol) && isa(b, Symbol) && isa(Ta, Symbol) && isa(Tb, Symbol)
+        if Ta == :Real && Tb == :Dual
+            return quote
+                @inline $(f){A<:ExternalReal,B<:Dual}(a::Dual{0,A}, b::Dual{0,B}) = Dual($(f)(value(a), value(b)))
+                @inline $(f){M,A<:ExternalReal,B<:Dual}(a::Dual{0,A}, b::Dual{M,B}) = $(f)(value(a), b)
+                @inline $(f){N,A<:ExternalReal,B<:Dual}(a::Dual{N,A}, b::Dual{0,B}) = $(f)(a, value(b))
+                @inline $(f){N,A<:ExternalReal,B<:Dual}($(a)::Dual{N,A}, $(b)::Dual{N,B}) = $(body)
+                @inline $(f){N,M,A<:ExternalReal,B<:Dual}($(a)::Dual{N,A}, $(b)::Dual{M,B}) = $(body)
+                $(esc(ex))
+            end
+        elseif Ta == :Dual && Tb == :Real
+            return quote
+                @inline $(f){A<:Dual,B<:ExternalReal}(a::Dual{0,A}, b::Dual{0,B}) = Dual($(f)(value(a), value(b)))
+                @inline $(f){M,A<:Dual,B<:ExternalReal}(a::Dual{0,A}, b::Dual{M,B}) = $(f)(value(a), b)
+                @inline $(f){N,A<:Dual,B<:ExternalReal}(a::Dual{N,A}, b::Dual{0,B}) = $(f)(a, value(b))
+                @inline $(f){N,A<:Dual,B<:ExternalReal}($(a)::Dual{N,A}, $(b)::Dual{N,B}) = $(body)
+                @inline $(f){N,M,A<:Dual,B<:ExternalReal}($(a)::Dual{N,A}, $(b)::Dual{M,B}) = $(body)
+                $(esc(ex))
             end
         else
-            if signbit(yi)==1 && !isnan(y)
-                yi = -yi
-                show(io, yr)
-                printtimes(io, yr)
-                print(io, "ɛ - ")
-                show(io, yi)
-            else
-                show(io, yr)
-                print(io, "ɛ + ")
-                show(io, yi)
-            end
+            return esc(ex)
         end
-        printtimes(io, yi)
-        print(io, "imɛ")
-    else
-        print(io, "Dual{",T,"}(", x, ",", y, ")")
     end
-end
-
-function dual_show{T<:Bool}(io::IO, z::Dual{T}, compact::Bool)
-    x, y = value(z), epsilon(z)
-    if !value(z) && epsilon(z)
-        print(io, "ɛ")
-    else
-        print(io, "Dual{",T,"}(", x, ",", y, ")")
-    end
-end
-
-function dual_show{T<:Bool}(io::IO, z::Dual{Complex{T}}, compact::Bool)
-    x, y = value(z), epsilon(z)
-    xr, xi = reim(x)
-    yr, yi = reim(y)
-    if !xr
-        if xi*!yr*!yi
-            print(io, "im")
-        elseif !xi*yr*!yi
-            print(io, "ɛ")
-        elseif !xi*!yr*yi
-            print(io, "imɛ")
+    return quote
+        @inline $(f){N,M,A<:Real,B<:Real}(a::Dual{N,A}, b::Dual{M,B}) = error("npartials($(typeof(a))) != npartials($(typeof(b)))")
+        if !(in($f, (isequal, ==, isless, <, <=, <)))
+            @inline $(f){A<:Real,B<:Real}(a::Dual{0,A}, b::Dual{0,B}) = Dual($(f)(value(a), value(b)))
+            @inline $(f){M,A<:Real,B<:Real}(a::Dual{0,A}, b::Dual{M,B}) = $(f)(value(a), b)
+            @inline $(f){N,A<:Real,B<:Real}(a::Dual{N,A}, b::Dual{0,B}) = $(f)(a, value(b))
         end
-    else
-        print(io, "Dual{",T,"}(", x, ",", y, ")")
+        $(esc(ex))
     end
 end
 
-function printtimes(io::IO, x::Real)
-    if !(isa(x,Integer) || isa(x,Rational) ||
-         isa(x,AbstractFloat) && isfinite(x))
-        print(io, "*")
-    end
+Base.copy(n::Dual) = n
+
+Base.eps(n::Dual) = eps(value(n))
+Base.eps{D<:Dual}(::Type{D}) = eps(valtype(D))
+
+Base.rtoldefault{N, T <: Real}(::Type{Dual{N,T}}) = Base.rtoldefault(T)
+
+Base.floor{T<:Real}(::Type{T}, n::Dual) = floor(T, value(n))
+Base.floor(n::Dual) = floor(value(n))
+
+Base.ceil{T<:Real}(::Type{T}, n::Dual) = ceil(T, value(n))
+Base.ceil(n::Dual) = ceil(value(n))
+
+Base.trunc{T<:Real}(::Type{T}, n::Dual) = trunc(T, value(n))
+Base.trunc(n::Dual) = trunc(value(n))
+
+Base.round{T<:Real}(::Type{T}, n::Dual) = round(T, value(n))
+Base.round(n::Dual) = round(value(n))
+
+Base.hash(n::Dual) = hash(value(n))
+Base.hash(n::Dual, hsh::UInt64) = hash(value(n), hsh)
+
+function Base.read{N,T}(io::IO, ::Type{Dual{N,T}})
+    value = read(io, T)
+    partials = read(io, Partials{N,T})
+    return Dual{N,T}(value, partials)
 end
 
-show(io::IO, z::Dual) = dual_show(io, z, false)
-showcompact(io::IO, z::Dual) = dual_show(io, z, true)
-
-function read{T<:ReComp}(s::IO, ::Type{Dual{T}})
-    x = read(s, T)
-    y = read(s, T)
-    Dual{T}(x, y)
-end
-function write(s::IO, z::Dual)
-    write(s, value(z))
-    write(s, epsilon(z))
+function Base.write(io::IO, n::Dual)
+    write(io, value(n))
+    write(io, partials(n))
 end
 
+@inline Base.zero(n::Dual) = zero(typeof(n))
+@inline Base.zero{N,T}(::Type{Dual{N,T}}) = Dual(zero(T), zero(Partials{N,T}))
 
-## Generic functions of dual numbers ##
+@inline Base.one(n::Dual) = one(typeof(n))
+@inline Base.one{N,T}(::Type{Dual{N,T}}) = Dual(one(T), zero(Partials{N,T}))
 
-convert(::Type{Dual}, z::Dual) = z
-convert(::Type{Dual}, x::Number) = Dual(x)
+@inline Base.rand(n::Dual) = rand(typeof(n))
+@inline Base.rand{N,T}(::Type{Dual{N,T}}) = Dual(rand(T), zero(Partials{N,T}))
+@inline Base.rand(rng::AbstractRNG, n::Dual) = rand(rng, typeof(n))
+@inline Base.rand{N,T}(rng::AbstractRNG, ::Type{Dual{N,T}}) = Dual(rand(rng, T), zero(Partials{N,T}))
 
-==(z::Dual, w::Dual) = value(z) == value(w)
-==(z::Dual, x::Number) = value(z) == x
-==(x::Number, z::Dual) = value(z) == x
+# Predicates #
+#------------#
 
-isequal(z::Dual, w::Dual) = isequal(value(z),value(w)) && isequal(epsilon(z), epsilon(w))
-isequal(z::Dual, x::Number) = isequal(value(z), x) && isequal(epsilon(z), zero(x))
-isequal(x::Number, z::Dual) = isequal(z, x)
+isconstant(n::Dual) = iszero(partials(n))
 
-isless{T<:Real}(z::Dual{T},w::Dual{T}) = value(z) < value(w)
-isless{T<:Real}(z::Real,w::Dual{T}) = z < value(w)
-isless{T<:Real}(z::Dual{T},w::Real) = value(z) < w
+@ambiguous Base.isequal{N}(a::Dual{N}, b::Dual{N}) = isequal(value(a), value(b))
+@ambiguous @compat(Base.:(==)){N}(a::Dual{N}, b::Dual{N}) = value(a) == value(b)
+@ambiguous Base.isless{N}(a::Dual{N}, b::Dual{N}) = value(a) < value(b)
+@ambiguous @compat(Base.:<){N}(a::Dual{N}, b::Dual{N}) = isless(a, b)
+@ambiguous @compat(Base.:(<=)){N}(a::Dual{N}, b::Dual{N}) = <=(value(a), value(b))
 
-hash(z::Dual) = (x = hash(value(z)); epsilon(z)==0 ? x : bitmix(x,hash(epsilon(z))))
+for T in (AbstractFloat, Irrational, Real)
+    Base.isequal(n::Dual, x::T) = isequal(value(n), x)
+    Base.isequal(x::T, n::Dual) = isequal(n, x)
 
-float{T<:AbstractFloat}(z::Union{Dual{T},Dual{Complex{T}}})=z
-complex{T<:Real}(z::Dual{Complex{T}})=z
+    @compat(Base.:(==))(n::Dual, x::T) = (value(n) == x)
+    @compat(Base.:(==))(x::T, n::Dual) = ==(n, x)
 
-floor{T<:Real}(::Type{T}, z::Dual) = floor(T, value(z))
-ceil{ T<:Real}(::Type{T}, z::Dual) = ceil( T, value(z))
-trunc{T<:Real}(::Type{T}, z::Dual) = trunc(T, value(z))
-round{T<:Real}(::Type{T}, z::Dual) = round(T, value(z))
+    Base.isless(n::Dual, x::T) = value(n) < x
+    Base.isless(x::T, n::Dual) = x < value(n)
 
-for op in (:real,:imag,:conj,:float,:complex)
+    @compat(Base.:<)(n::Dual, x::T) = isless(n, x)
+    @compat(Base.:<)(x::T, n::Dual) = isless(x, n)
+
+    @compat(Base.:(<=))(n::Dual, x::T) = <=(value(n), x)
+    @compat(Base.:(<=))(x::T, n::Dual) = <=(x, value(n))
+end
+
+Base.isnan(n::Dual) = isnan(value(n))
+Base.isfinite(n::Dual) = isfinite(value(n))
+Base.isinf(n::Dual) = isinf(value(n))
+Base.isreal(n::Dual) = isreal(value(n))
+Base.isinteger(n::Dual) = isinteger(value(n))
+Base.iseven(n::Dual) = iseven(value(n))
+Base.isodd(n::Dual) = isodd(value(n))
+
+########################
+# Promotion/Conversion #
+########################
+
+Base.promote_rule{N1,N2,A<:Real,B<:Real}(D1::Type{Dual{N1,A}}, D2::Type{Dual{N2,B}}) = error("can't promote $(D1) and $(D2)")
+Base.promote_rule{N,A<:Real,B<:Real}(::Type{Dual{N,A}}, ::Type{Dual{N,B}}) = Dual{N,promote_type(A, B)}
+Base.promote_rule{N,T<:Real}(::Type{Dual{N,T}}, ::Type{BigFloat}) = Dual{N,promote_type(T, BigFloat)}
+Base.promote_rule{N,T<:Real}(::Type{BigFloat}, ::Type{Dual{N,T}}) = Dual{N,promote_type(BigFloat, T)}
+Base.promote_rule{N,T<:Real}(::Type{Dual{N,T}}, ::Type{Bool}) = Dual{N,promote_type(T, Bool)}
+Base.promote_rule{N,T<:Real}(::Type{Bool}, ::Type{Dual{N,T}}) = Dual{N,promote_type(Bool, T)}
+Base.promote_rule{N,T<:Real,s}(::Type{Dual{N,T}}, ::Type{Irrational{s}}) = Dual{N,promote_type(T, Irrational{s})}
+Base.promote_rule{N,s,T<:Real}(::Type{Irrational{s}}, ::Type{Dual{N,T}}) = Dual{N,promote_type(Irrational{s}, T)}
+Base.promote_rule{N,A<:Real,B<:Real}(::Type{Dual{N,A}}, ::Type{B}) = Dual{N,promote_type(A, B)}
+Base.promote_rule{N,A<:Real,B<:Real}(::Type{A}, ::Type{Dual{N,B}}) = Dual{N,promote_type(A, B)}
+
+Base.convert(::Type{Dual}, n::Dual) = n
+Base.convert{N,T<:Real}(::Type{Dual{N,T}}, n::Dual{N}) = Dual(convert(T, value(n)), convert(Partials{N,T}, partials(n)))
+Base.convert{D<:Dual}(::Type{D}, n::D) = n
+Base.convert{N,T<:Real}(::Type{Dual{N,T}}, x::Real) = Dual(convert(T, x), zero(Partials{N,T}))
+Base.convert(::Type{Dual}, x::Real) = Dual(x)
+
+Base.promote_array_type{D<:Dual, A<:AbstractFloat}(F, ::Type{D}, ::Type{A}) = promote_type(D, A)
+Base.promote_array_type{D<:Dual, A<:AbstractFloat, P}(F, ::Type{D}, ::Type{A}, ::Type{P}) = P
+Base.promote_array_type{A<:AbstractFloat, D<:Dual}(F, ::Type{A}, ::Type{D}) = promote_type(D, A)
+Base.promote_array_type{A<:AbstractFloat, D<:Dual, P}(F, ::Type{A}, ::Type{D}, ::Type{P}) = P
+
+Base.float{N,T}(n::Dual{N,T}) = Dual{N,promote_type(T, Float16)}(n)
+
+########
+# Math #
+########
+
+# Addition/Subtraction #
+#----------------------#
+
+@ambiguous @inline @compat(Base.:+){N}(n1::Dual{N}, n2::Dual{N}) = Dual(value(n1) + value(n2), partials(n1) + partials(n2))
+@ambiguous @inline @compat(Base.:+)(n::Dual, x::Real) = Dual(value(n) + x, partials(n))
+@ambiguous @inline @compat(Base.:+)(x::Real, n::Dual) = n + x
+
+@ambiguous @inline @compat(Base.:-){N}(n1::Dual{N}, n2::Dual{N}) = Dual(value(n1) - value(n2), partials(n1) - partials(n2))
+@ambiguous @inline @compat(Base.:-)(n::Dual, x::Real) = Dual(value(n) - x, partials(n))
+@ambiguous @inline @compat(Base.:-)(x::Real, n::Dual) = Dual(x - value(n), -(partials(n)))
+@inline @compat(Base.:-)(n::Dual) = Dual(-(value(n)), -(partials(n)))
+
+# Multiplication #
+#----------------#
+
+@inline @compat(Base.:*)(n::Dual, x::Bool) = x ? n : (signbit(value(n))==0 ? zero(n) : -zero(n))
+@inline @compat(Base.:*)(x::Bool, n::Dual) = n * x
+
+@ambiguous @inline function @compat(Base.:*){N}(n1::Dual{N}, n2::Dual{N})
+    v1, v2 = value(n1), value(n2)
+    return Dual(v1 * v2, _mul_partials(partials(n1), partials(n2), v2, v1))
+end
+
+@ambiguous @inline @compat(Base.:*)(n::Dual, x::Real) = Dual(value(n) * x, partials(n) * x)
+@ambiguous @inline @compat(Base.:*)(x::Real, n::Dual) = n * x
+
+# Division #
+#----------#
+
+@ambiguous @inline function @compat(Base.:/){N}(n1::Dual{N}, n2::Dual{N})
+    v1, v2 = value(n1), value(n2)
+    return Dual(v1 / v2, _div_partials(partials(n1), partials(n2), v1, v2))
+end
+
+@ambiguous @inline function @compat(Base.:/)(x::Real, n::Dual)
+    v = value(n)
+    divv = x / v
+    return Dual(divv, -(divv / v) * partials(n))
+end
+
+@ambiguous @inline @compat(Base.:/)(n::Dual, x::Real) = Dual(value(n) / x, partials(n) / x)
+
+# Exponentiation #
+#----------------#
+
+for f in (macroexpand(:(@compat(Base.:^))), :(NaNMath.pow))
     @eval begin
-        $op(z::Dual) = Dual($op(value(z)),$op(epsilon(z)))
-    end
-end
-
-abs(z::Dual) = sqrt(abs2(z))
-abs2(z::Dual) = real(conj(z)*z)
-
-real{T<:Real}(z::Dual{T}) = z
-abs{T<:Real}(z::Dual{T}) = z ≥ 0 ? z : -z
-
-angle{T<:Real}(z::Dual{T}) = z ≥ 0 ? zero(z) : one(z)*π
-angle{T<:Real}(z::Dual{Complex{T}}) = z == 0 ? (imag(epsilon(z)) == 0 ? Dual(zero(T),zero(T)) : Dual(zero(T),convert(T, Inf))) : real(log(sign(z))/im)
-
-# algebraic definitions
-conjdual(z::Dual) = Dual(value(z),-epsilon(z))
-absdual(z::Dual) = abs(value(z))
-abs2dual(z::Dual) = abs2(value(z))
-
-# algebra
-
-+(z::Dual, w::Dual) = Dual(value(z)+value(w), epsilon(z)+epsilon(w))
-+(z::Number, w::Dual) = Dual(z+value(w), epsilon(w))
-+(z::Dual, w::Number) = Dual(value(z)+w, epsilon(z))
-
--(z::Dual) = Dual(-value(z), -epsilon(z))
--(z::Dual, w::Dual) = Dual(value(z)-value(w), epsilon(z)-epsilon(w))
--(z::Number, w::Dual) = Dual(z-value(w), -epsilon(w))
--(z::Dual, w::Number) = Dual(value(z)-w, epsilon(z))
-
-# avoid ambiguous definition with Bool*Number
-*(x::Bool, z::Dual) = ifelse(x, z, ifelse(signbit(real(value(z)))==0, zero(z), -zero(z)))
-*(x::Dual, z::Bool) = z*x
-
-*(z::Dual, w::Dual) = Dual(value(z)*value(w), epsilon(z)*value(w)+value(z)*epsilon(w))
-*(x::Number, z::Dual) = Dual(x*value(z), x*epsilon(z))
-*(z::Dual, x::Number) = Dual(x*value(z), x*epsilon(z))
-
-/(z::Dual, w::Dual) = Dual(value(z)/value(w), (epsilon(z)*value(w)-value(z)*epsilon(w))/(value(w)*value(w)))
-/(z::Number, w::Dual) = Dual(z/value(w), -z*epsilon(w)/value(w)^2)
-/(z::Dual, x::Number) = Dual(value(z)/x, epsilon(z)/x)
-
-for f in [:^, :(NaNMath.pow)]
-    @eval function ($f)(z::Dual, w::Dual)
-        if epsilon(w) == 0.0
-            return $f(z,value(w))
+        @ambiguous @inline function ($f){N}(n1::Dual{N}, n2::Dual{N})
+            v1, v2 = value(n1), value(n2)
+            expv = ($f)(v1, v2)
+            powval = v2 * ($f)(v1, v2 - 1)
+            logval = isconstant(n2) ? one(expv) : expv * log(v1)
+            new_partials = _mul_partials(partials(n1), partials(n2), powval, logval)
+            return Dual(expv, new_partials)
         end
-        val = $f(value(z),value(w))
 
-        du =
-        epsilon(z)*value(w)*(($f)(value(z),value(w)-1))+epsilon(w)*($f)(value(z),value(w))*log(value(z))
+        @inline ($f)(::Base.Irrational{:e}, n::Dual) = exp(n)
+    end
 
-        Dual(val, du)
+    for T in (:Integer, :Rational, :Real)
+        @eval begin
+            @ambiguous @inline function ($f)(n::Dual, x::$(T))
+                v = value(n)
+                expv = ($f)(v, x)
+                deriv = x * ($f)(v, x - 1)
+                return Dual(expv, deriv * partials(n))
+            end
+
+            @ambiguous @inline function ($f)(x::$(T), n::Dual)
+                v = value(n)
+                expv = ($f)(x, v)
+                deriv = expv*log(x)
+                return Dual(expv, deriv * partials(n))
+            end
+        end
     end
 end
 
-mod(z::Dual, n::Number) = Dual(mod(value(z), n), epsilon(z))
+# Unary Math Functions #
+#--------------------- #
 
-# these two definitions are needed to fix ambiguity warnings
-^(z::Dual, n::Integer) = Dual(value(z)^n, epsilon(z)*n*value(z)^(n-1))
-^(z::Dual, n::Rational) = Dual(value(z)^n, epsilon(z)*n*value(z)^(n-1))
-
-^(z::Dual, n::Number) = Dual(value(z)^n, epsilon(z)*n*value(z)^(n-1))
-NaNMath.pow(z::Dual, n::Number) = Dual(NaNMath.pow(value(z),n), epsilon(z)*n*NaNMath.pow(value(z),n-1))
-NaNMath.pow(z::Number, w::Dual) = Dual(NaNMath.pow(z,value(w)), epsilon(w)*NaNMath.pow(z,value(w))*log(z))
-
-# force use of NaNMath functions in derivative calculations
 function to_nanmath(x::Expr)
     if x.head == :call
         funsym = Expr(:.,:NaNMath,Base.Meta.quot(x.args[1]))
@@ -264,36 +296,121 @@ function to_nanmath(x::Expr)
         return Expr(:call,[to_nanmath(z) for z in x.args]...)
     end
 end
+
 to_nanmath(x) = x
 
-for (funsym, exp) in Calculus.symbolic_derivatives_1arg()
-    funsym == :exp && continue
-    funsym == :abs2 && continue
-    @eval function $(funsym)(z::Dual)
-        x = value(z)
-        xp = epsilon(z)
-        Dual($(funsym)(x),xp*$exp)
+@inline Base.conj(n::Dual) = n
+@inline Base.transpose(n::Dual) = n
+@inline Base.ctranspose(n::Dual) = n
+@inline Base.abs(n::Dual) = signbit(value(n)) ? -n : n
+
+for fsym in AUTO_DEFINED_UNARY_FUNCS
+    v = :v
+    deriv = Calculus.differentiate(:($(fsym)($v)), v)
+
+    # exp and sqrt are manually defined below
+    if !(in(fsym, (:exp, :sqrt)))
+        @eval begin
+            @inline function Base.$(fsym)(n::Dual)
+                $(v) = value(n)
+                return Dual($(fsym)($v), $(deriv) * partials(n))
+            end
+        end
     end
+
     # extend corresponding NaNMath methods
-    if funsym in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
-          :lgamma, :log1p)
-        funsym = Expr(:.,:NaNMath,Base.Meta.quot(funsym))
-        @eval function $(funsym)(z::Dual)
-            x = value(z)
-            xp = epsilon(z)
-            Dual($(funsym)(x),xp*$(to_nanmath(exp)))
+    if fsym in NANMATH_FUNCS
+        nan_deriv = to_nanmath(deriv)
+        @eval begin
+            @inline function NaNMath.$(fsym)(n::Dual)
+                v = value(n)
+                return Dual(NaNMath.$(fsym)($v), $(nan_deriv) * partials(n))
+            end
         end
     end
 end
 
-# only need to compute exp/cis once
-exp(z::Dual) = (expval = exp(value(z)); Dual(expval, epsilon(z)*expval))
-cis(z::Dual) = (cisval = cis(value(z)); Dual(cisval, im*epsilon(z)*cisval))
+#################
+# Special Cases #
+#################
 
-## TODO: should be generated in Calculus
-sinpi(z::Dual) = Dual(sinpi(value(z)),epsilon(z)*cospi(value(z))*π)
-cospi(z::Dual) = Dual(cospi(value(z)),-epsilon(z)*sinpi(value(z))*π)
+# Manually Optimized Functions #
+#------------------------------#
 
-if VERSION >= v"0.5.0-dev+5429"
-    Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Dual) = checkindex(Bool, inds, value(i))
+@inline function Base.exp{N}(n::Dual{N})
+    expv = exp(value(n))
+    return Dual(expv, expv * partials(n))
+end
+
+@inline function Base.sqrt{N}(n::Dual{N})
+    sqrtv = sqrt(value(n))
+    deriv = inv(sqrtv + sqrtv)
+    return Dual(sqrtv, deriv * partials(n))
+end
+
+@inline function calc_hypot(x, y)
+    vx = value(x)
+    vy = value(y)
+    h = hypot(vx, vy)
+    return Dual(h, (vx/h) * partials(x) + (vy/h) * partials(y))
+end
+
+@inline function calc_hypot(x, y, z)
+    vx = value(x)
+    vy = value(y)
+    vz = value(z)
+    h = hypot(vx, vy, vz)
+    return Dual(h, (vx/h) * partials(x) + (vy/h) * partials(y) + (vz/h) * partials(z))
+end
+
+@ambiguous @inline Base.hypot{N}(x::Dual{N}, y::Dual{N}) = calc_hypot(x, y)
+@ambiguous @inline Base.hypot(x::Dual, y::Real) = calc_hypot(x, y)
+@ambiguous @inline Base.hypot(x::Real, y::Dual) = calc_hypot(x, y)
+
+@inline Base.hypot(x::Dual, y::Dual, z::Dual) = calc_hypot(x, y, z)
+
+@inline Base.hypot(x::Real, y::Dual, z::Dual) = calc_hypot(x, y, z)
+@inline Base.hypot(x::Dual, y::Real, z::Dual) = calc_hypot(x, y, z)
+@inline Base.hypot(x::Dual, y::Dual, z::Real) = calc_hypot(x, y, z)
+
+@inline Base.hypot(x::Dual, y::Real, z::Real) = calc_hypot(x, y, z)
+@inline Base.hypot(x::Real, y::Dual, z::Real) = calc_hypot(x, y, z)
+@inline Base.hypot(x::Real, y::Real, z::Dual) = calc_hypot(x, y, z)
+
+@inline sincos(n) = (sin(n), cos(n))
+
+@inline function sincos(n::Dual)
+    sn, cn = sincos(value(n))
+    return (Dual(sn, cn * partials(n)), Dual(cn, -sn * partials(n)))
+end
+
+# Other Functions #
+#-----------------#
+
+@inline function calc_atan2(y, x)
+    z = y / x
+    v = value(z)
+    atan2v = atan2(value(y), value(x))
+    deriv = inv(one(v) + v*v)
+    return Dual(atan2v, deriv * partials(z))
+end
+
+@ambiguous @inline Base.atan2{N}(y::Dual{N}, x::Dual{N}) = calc_atan2(y, x)
+@ambiguous @inline Base.atan2(y::Real, x::Dual) = calc_atan2(y, x)
+@ambiguous @inline Base.atan2(y::Dual, x::Real) = calc_atan2(y, x)
+
+###################
+# Pretty Printing #
+###################
+
+function Base.show{N}(io::IO, n::Dual{N})
+    print(io, value(n))
+    print(io, " + ")
+    for i in 1:N-1
+        sub = string(2080 + i)
+        print(io, partials(n, i), "ϵ", unescape_string("\\" * "u" * sub))
+        print(io, " + ")
+    end
+    sub = string(2080 + N)
+    print(io, partials(n, N), "ϵ", unescape_string("\\" * "u" * sub))
 end

--- a/src/partials.jl
+++ b/src/partials.jl
@@ -1,0 +1,214 @@
+immutable Partials{N,T} <: AbstractVector{T}
+    values::NTuple{N,T}
+end
+
+##############################
+# Utility/Accessor Functions #
+##############################
+
+@inline valtype{N,T}(::Partials{N,T}) = T
+@inline valtype{N,T}(::Type{Partials{N,T}}) = T
+
+@inline npartials{N}(::Partials{N}) = N
+@inline npartials{N,T}(::Type{Partials{N,T}}) = N
+
+@inline Base.length{N}(::Partials{N}) = N
+@inline Base.size{N}(::Partials{N}) = (N,)
+
+@inline Base.getindex(partials::Partials, i::Int) = partials.values[i]
+setindex{N,T}(partials::Partials{N,T}, v, i) = Partials{N,T}((partials[1:i-1]..., v, partials[i+1:N]...))
+
+Base.start(partials::Partials) = start(partials.values)
+Base.next(partials::Partials, i) = next(partials.values, i)
+Base.done(partials::Partials, i) = done(partials.values, i)
+
+Base.linearindexing(::Partials) = Base.LinearFast()
+
+#####################
+# Generic Functions #
+#####################
+
+@inline iszero(partials::Partials) = iszero_tuple(partials.values)
+
+@inline Base.zero(partials::Partials) = zero(typeof(partials))
+@inline Base.zero{N,T}(::Type{Partials{N,T}}) = Partials{N,T}(zero_tuple(NTuple{N,T}))
+
+@inline Base.one(partials::Partials) = one(typeof(partials))
+@inline Base.one{N,T}(::Type{Partials{N,T}}) = Partials{N,T}(one_tuple(NTuple{N,T}))
+
+@inline Base.rand(partials::Partials) = rand(typeof(partials))
+@inline Base.rand{N,T}(::Type{Partials{N,T}}) = Partials{N,T}(rand_tuple(NTuple{N,T}))
+@inline Base.rand(rng::AbstractRNG, partials::Partials) = rand(rng, typeof(partials))
+@inline Base.rand{N,T}(rng::AbstractRNG, ::Type{Partials{N,T}}) = Partials{N,T}(rand_tuple(rng, NTuple{N,T}))
+
+Base.isequal{N}(a::Partials{N}, b::Partials{N}) = isequal(a.values, b.values)
+@compat(Base.:(==)){N}(a::Partials{N}, b::Partials{N}) = a.values == b.values
+
+const PARTIALS_HASH = hash(Partials)
+
+Base.hash(partials::Partials) = hash(partials.values, PARTIALS_HASH)
+Base.hash(partials::Partials, hsh::UInt64) = hash(hash(partials), hsh)
+
+@inline Base.copy(partials::Partials) = partials
+
+Base.read{N,T}(io::IO, ::Type{Partials{N,T}}) = Partials{N,T}(ntuple(i->read(io, T), Val{N}))
+
+function Base.write(io::IO, partials::Partials)
+    for p in partials
+        write(io, p)
+    end
+end
+
+########################
+# Conversion/Promotion #
+########################
+
+Base.promote_rule{N,A,B}(::Type{Partials{N,A}}, ::Type{Partials{N,B}}) = Partials{N,promote_type(A, B)}
+
+Base.convert{N,T}(::Type{Partials{N,T}}, partials::Partials) = Partials{N,T}(partials.values)
+Base.convert{N,T}(::Type{Partials{N,T}}, partials::Partials{N,T}) = partials
+
+########################
+# Arithmetic Functions #
+########################
+
+@inline @compat(Base.:+){N}(a::Partials{N}, b::Partials{N}) = Partials(add_tuples(a.values, b.values))
+@inline @compat(Base.:-){N}(a::Partials{N}, b::Partials{N}) = Partials(sub_tuples(a.values, b.values))
+@inline @compat(Base.:-)(partials::Partials) = Partials(minus_tuple(partials.values))
+@inline @compat(Base.:*)(x::Real, partials::Partials) = partials*x
+
+@inline function _div_partials(a::Partials, b::Partials, aval, bval)
+    return _mul_partials(a, b, inv(bval), -(aval / (bval*bval)))
+end
+
+# NaN/Inf-safe methods #
+#----------------------#
+
+if NANSAFE_MODE_ENABLED
+    @inline function @compat(Base.:*)(partials::Partials, x::Real)
+        x = ifelse(!isfinite(x) && iszero(partials), one(x), x)
+        return Partials(scale_tuple(partials.values, x))
+    end
+
+    @inline function @compat(Base.:/)(partials::Partials, x::Real)
+        x = ifelse(x == zero(x) && iszero(partials), one(x), x)
+        return Partials(div_tuple_by_scalar(partials.values, x))
+    end
+
+    @inline function _mul_partials{N}(a::Partials{N}, b::Partials{N}, x_a, x_b)
+        x_a = ifelse(!isfinite(x_a) && iszero(a), one(x_a), x_a)
+        x_b = ifelse(!isfinite(x_b) && iszero(b), one(x_b), x_b)
+        return Partials(mul_tuples(a.values, b.values, x_a, x_b))
+    end
+else
+    @inline function @compat(Base.:*)(partials::Partials, x::Real)
+        return Partials(scale_tuple(partials.values, x))
+    end
+
+    @inline function @compat(Base.:/)(partials::Partials, x::Real)
+        return Partials(div_tuple_by_scalar(partials.values, x))
+    end
+
+    @inline function _mul_partials{N}(a::Partials{N}, b::Partials{N}, x_a, x_b)
+        return Partials(mul_tuples(a.values, b.values, x_a, x_b))
+    end
+end
+
+# edge cases where N == 0 #
+#-------------------------#
+
+@inline @compat(Base.:+){A,B}(a::Partials{0,A}, b::Partials{0,B}) = Partials{0,promote_type(A,B)}(tuple())
+@inline @compat(Base.:-){A,B}(a::Partials{0,A}, b::Partials{0,B}) = Partials{0,promote_type(A,B)}(tuple())
+@inline @compat(Base.:-){T}(partials::Partials{0,T}) = partials
+@inline @compat(Base.:*){T}(partials::Partials{0,T}, x::Real) = Partials{0,promote_type(T,typeof(x))}(tuple())
+@inline @compat(Base.:*){T}(x::Real, partials::Partials{0,T}) = Partials{0,promote_type(T,typeof(x))}(tuple())
+@inline @compat(Base.:/){T}(partials::Partials{0,T}, x::Real) = Partials{0,promote_type(T,typeof(x))}(tuple())
+
+@inline _mul_partials{A,B}(a::Partials{0,A}, b::Partials{0,B}, afactor, bfactor) = Partials{0,promote_type(A,B)}(tuple())
+@inline _div_partials{A,B}(a::Partials{0,A}, b::Partials{0,B}, afactor, bfactor) = Partials{0,promote_type(A,B)}(tuple())
+
+##################################
+# Generated Functions on NTuples #
+##################################
+# The below functions are generally
+# equivalent to directly mapping over
+# tuples using `map`, but run a bit
+# faster since they generate inline code
+# that doesn't rely on closures.
+
+function tupexpr(f, N)
+    ex = Expr(:tuple, [f(i) for i=1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds return $ex
+    end
+end
+
+@inline iszero_tuple(::Tuple{}) = true
+@inline zero_tuple(::Type{Tuple{}}) = tuple()
+@inline one_tuple(::Type{Tuple{}}) = tuple()
+@inline rand_tuple(::AbstractRNG, ::Type{Tuple{}}) = tuple()
+@inline rand_tuple(::Type{Tuple{}}) = tuple()
+
+@generated function iszero_tuple{N,T}(tup::NTuple{N,T})
+    ex = Expr(:&&, [:(z == tup[$i]) for i=1:N]...)
+    return quote
+        z = zero(T)
+        $(Expr(:meta, :inline))
+        @inbounds return $ex
+    end
+end
+
+@generated function zero_tuple{N,T}(::Type{NTuple{N,T}})
+    ex = tupexpr(i -> :(z), N)
+    return quote
+        z = zero(T)
+        return $ex
+    end
+end
+
+@generated function one_tuple{N,T}(::Type{NTuple{N,T}})
+    ex = tupexpr(i -> :(z), N)
+    return quote
+        z = one(T)
+        return $ex
+    end
+end
+
+@generated function rand_tuple{N,T}(rng::AbstractRNG, ::Type{NTuple{N,T}})
+    return tupexpr(i -> :(rand(rng, T)), N)
+end
+
+@generated function rand_tuple{N,T}(::Type{NTuple{N,T}})
+    return tupexpr(i -> :(rand(T)), N)
+end
+
+@generated function scale_tuple{N}(tup::NTuple{N}, x)
+    return tupexpr(i -> :(tup[$i] * x), N)
+end
+
+@generated function div_tuple_by_scalar{N}(tup::NTuple{N}, x)
+    return tupexpr(i -> :(tup[$i] / x), N)
+end
+
+@generated function add_tuples{N}(a::NTuple{N}, b::NTuple{N})
+    return tupexpr(i -> :(a[$i] + b[$i]), N)
+end
+
+@generated function sub_tuples{N}(a::NTuple{N}, b::NTuple{N})
+    return tupexpr(i -> :(a[$i] - b[$i]), N)
+end
+
+@generated function minus_tuple{N}(tup::NTuple{N})
+    return tupexpr(i -> :(-tup[$i]), N)
+end
+
+@generated function mul_tuples{N}(a::NTuple{N}, b::NTuple{N}, afactor, bfactor)
+    return tupexpr(i -> :((afactor * a[$i]) + (bfactor * b[$i])), N)
+end
+
+###################
+# Pretty Printing #
+###################
+
+Base.show{N}(io::IO, p::Partials{N}) = print(io, "Partials", p.values)

--- a/test/DualTest.jl
+++ b/test/DualTest.jl
@@ -1,0 +1,448 @@
+module DualTest
+
+using Base.Test
+using ForwardDiff
+using ForwardDiff: Partials, Dual, value, partials
+
+import NaNMath
+import Calculus
+
+samerng() = MersenneTwister(1)
+
+# By lower-bounding the Int range at 2, we avoid cases where differentiating an
+# exponentiation of an Int value would cause a DomainError due to reducing the
+# exponent by one
+intrand(T) = T == Int ? rand(2:10) : rand(T)
+
+# fix testing issue with Base.hypot(::Int...) undefined in 0.4
+if v"0.4" <= VERSION < v"0.5"
+    Base.hypot(x::Int, y::Int) = Base.hypot(Float64(x), Float64(y))
+    Base.hypot(x, y, z) = hypot(hypot(x, y), z)
+end
+
+if VERSION < v"0.5"
+    # isapprox on v0.4 doesn't properly set the tolerance
+    # for mixed-precision inputs, while @test_approx_eq does
+    # Use @eval to avoid expanding @test_approx_eq on 0.6 where it's deprecated
+    @eval test_approx_diffnums(a::Real, b::Real) = @test_approx_eq a b
+else
+    test_approx_diffnums(a::Real, b::Real) = @test isapprox(a, b)
+end
+
+function test_approx_diffnums{N}(a::Dual{N}, b::Dual{N})
+    test_approx_diffnums(value(a), value(b))
+    for i in 1:N
+        test_approx_diffnums(partials(a)[i], partials(b)[i])
+    end
+end
+
+for N in (0,3), M in (0,4), T in (Int, Float32)
+    println("  ...testing Dual{$N,$T} and Dual{$N,Dual{$M,$T}}")
+
+    PARTIALS = Partials{N,T}(ntuple(n -> intrand(T), Val{N}))
+    PRIMAL = intrand(T)
+    FDNUM = Dual(PRIMAL, PARTIALS)
+
+    PARTIALS2 = Partials{N,T}(ntuple(n -> intrand(T), Val{N}))
+    PRIMAL2 = intrand(T)
+    FDNUM2 = Dual(PRIMAL2, PARTIALS2)
+
+    M_PARTIALS = Partials{M,T}(ntuple(m -> intrand(T), Val{M}))
+    NESTED_PARTIALS = convert(Partials{N,Dual{M,T}}, PARTIALS)
+    NESTED_FDNUM = Dual(Dual(PRIMAL, M_PARTIALS), NESTED_PARTIALS)
+
+    M_PARTIALS2 = Partials{M,T}(ntuple(m -> intrand(T), Val{M}))
+    NESTED_PARTIALS2 = convert(Partials{N,Dual{M,T}}, PARTIALS2)
+    NESTED_FDNUM2 = Dual(Dual(PRIMAL2, M_PARTIALS2), NESTED_PARTIALS2)
+
+    ################
+    # Constructors #
+    ################
+
+    @test Dual(PRIMAL, PARTIALS...) === FDNUM
+    @test typeof(Dual(widen(T)(PRIMAL), PARTIALS)) === Dual{N,widen(T)}
+    @test typeof(Dual(widen(T)(PRIMAL), PARTIALS.values)) === Dual{N,widen(T)}
+    @test typeof(Dual(widen(T)(PRIMAL), PARTIALS...)) === Dual{N,widen(T)}
+    @test typeof(NESTED_FDNUM) == Dual{N,Dual{M,T}}
+
+    #############
+    # Accessors #
+    #############
+
+    @test value(PRIMAL) == PRIMAL
+    @test value(FDNUM) == PRIMAL
+    @test value(NESTED_FDNUM) === Dual(PRIMAL, M_PARTIALS)
+
+    @test partials(PRIMAL) == Partials{0,T}(tuple())
+    @test partials(FDNUM) == PARTIALS
+    @test partials(NESTED_FDNUM) === NESTED_PARTIALS
+
+    for i in 1:N
+        @test partials(FDNUM, i) == PARTIALS[i]
+        for j in 1:M
+            @test partials(NESTED_FDNUM, i, j) == partials(NESTED_PARTIALS[i], j)
+        end
+    end
+
+    @test ForwardDiff.npartials(FDNUM) == N
+    @test ForwardDiff.npartials(typeof(FDNUM)) == N
+    @test ForwardDiff.npartials(NESTED_FDNUM) == N
+    @test ForwardDiff.npartials(typeof(NESTED_FDNUM)) == N
+
+    @test ForwardDiff.valtype(FDNUM) == T
+    @test ForwardDiff.valtype(typeof(FDNUM)) == T
+    @test ForwardDiff.valtype(NESTED_FDNUM) == Dual{M,T}
+    @test ForwardDiff.valtype(typeof(NESTED_FDNUM)) == Dual{M,T}
+
+    #####################
+    # Generic Functions #
+    #####################
+
+    @test FDNUM === copy(FDNUM)
+    @test NESTED_FDNUM === copy(NESTED_FDNUM)
+
+    if T != Int
+        @test eps(FDNUM) === eps(PRIMAL)
+        @test eps(typeof(FDNUM)) === eps(T)
+        @test eps(NESTED_FDNUM) === eps(PRIMAL)
+        @test eps(typeof(NESTED_FDNUM)) === eps(T)
+
+        @test floor(Int, FDNUM) === floor(Int, PRIMAL)
+        @test floor(Int, FDNUM2) === floor(Int, PRIMAL2)
+        @test floor(Int, NESTED_FDNUM) === floor(Int, PRIMAL)
+
+        @test floor(FDNUM) === floor(PRIMAL)
+        @test floor(FDNUM2) === floor(PRIMAL2)
+        @test floor(NESTED_FDNUM) === floor(PRIMAL)
+
+        @test ceil(Int, FDNUM) === ceil(Int, PRIMAL)
+        @test ceil(Int, FDNUM2) === ceil(Int, PRIMAL2)
+        @test ceil(Int, NESTED_FDNUM) === ceil(Int, PRIMAL)
+
+        @test ceil(FDNUM) === ceil(PRIMAL)
+        @test ceil(FDNUM2) === ceil(PRIMAL2)
+        @test ceil(NESTED_FDNUM) === ceil(PRIMAL)
+
+        @test trunc(Int, FDNUM) === trunc(Int, PRIMAL)
+        @test trunc(Int, FDNUM2) === trunc(Int, PRIMAL2)
+        @test trunc(Int, NESTED_FDNUM) === trunc(Int, PRIMAL)
+
+        @test trunc(FDNUM) === trunc(PRIMAL)
+        @test trunc(FDNUM2) === trunc(PRIMAL2)
+        @test trunc(NESTED_FDNUM) === trunc(PRIMAL)
+
+        @test round(Int, FDNUM) === round(Int, PRIMAL)
+        @test round(Int, FDNUM2) === round(Int, PRIMAL2)
+        @test round(Int, NESTED_FDNUM) === round(Int, PRIMAL)
+
+        @test round(FDNUM) === round(PRIMAL)
+        @test round(FDNUM2) === round(PRIMAL2)
+        @test round(NESTED_FDNUM) === round(PRIMAL)
+
+        @test Base.rtoldefault(typeof(FDNUM)) ≡ Base.rtoldefault(typeof(PRIMAL))
+        @test Dual(PRIMAL-eps(T), PARTIALS) ≈ FDNUM
+        @test Base.rtoldefault(typeof(NESTED_FDNUM)) ≡ Base.rtoldefault(typeof(PRIMAL))
+    end
+
+    @test hash(FDNUM) === hash(PRIMAL)
+    @test hash(FDNUM, hash(PRIMAL)) === hash(PRIMAL, hash(PRIMAL))
+    @test hash(NESTED_FDNUM) === hash(PRIMAL)
+    @test hash(NESTED_FDNUM, hash(PRIMAL)) === hash(PRIMAL, hash(PRIMAL))
+
+    const TMPIO = IOBuffer()
+    write(TMPIO, FDNUM)
+    seekstart(TMPIO)
+    @test read(TMPIO, typeof(FDNUM)) === FDNUM
+    seekstart(TMPIO)
+    write(TMPIO, FDNUM2)
+    seekstart(TMPIO)
+    @test read(TMPIO, typeof(FDNUM2)) === FDNUM2
+    seekstart(TMPIO)
+    write(TMPIO, NESTED_FDNUM)
+    seekstart(TMPIO)
+    @test read(TMPIO, typeof(NESTED_FDNUM)) === NESTED_FDNUM
+    close(TMPIO)
+
+    @test zero(FDNUM) === Dual(zero(PRIMAL), zero(PARTIALS))
+    @test zero(typeof(FDNUM)) === Dual(zero(T), zero(Partials{N,T}))
+    @test zero(NESTED_FDNUM) === Dual(Dual(zero(PRIMAL), zero(M_PARTIALS)), zero(NESTED_PARTIALS))
+    @test zero(typeof(NESTED_FDNUM)) === Dual(Dual(zero(T), zero(Partials{M,T})), zero(Partials{N,Dual{M,T}}))
+
+    @test one(FDNUM) === Dual(one(PRIMAL), zero(PARTIALS))
+    @test one(typeof(FDNUM)) === Dual(one(T), zero(Partials{N,T}))
+    @test one(NESTED_FDNUM) === Dual(Dual(one(PRIMAL), zero(M_PARTIALS)), zero(NESTED_PARTIALS))
+    @test one(typeof(NESTED_FDNUM)) === Dual(Dual(one(T), zero(Partials{M,T})), zero(Partials{N,Dual{M,T}}))
+
+    @test rand(samerng(), FDNUM) === Dual(rand(samerng(), T), zero(PARTIALS))
+    @test rand(samerng(), typeof(FDNUM)) === Dual(rand(samerng(), T), zero(Partials{N,T}))
+    @test rand(samerng(), NESTED_FDNUM) === Dual(Dual(rand(samerng(), T), zero(M_PARTIALS)), zero(NESTED_PARTIALS))
+    @test rand(samerng(), typeof(NESTED_FDNUM)) === Dual(Dual(rand(samerng(), T), zero(Partials{M,T})), zero(Partials{N,Dual{M,T}}))
+
+    # Predicates #
+    #------------#
+
+    @test ForwardDiff.isconstant(zero(FDNUM))
+    @test ForwardDiff.isconstant(rand(FDNUM))
+    @test ForwardDiff.isconstant(one(FDNUM))
+    @test ForwardDiff.isconstant(FDNUM) == (N == 0)
+
+    @test ForwardDiff.isconstant(zero(NESTED_FDNUM))
+    @test ForwardDiff.isconstant(rand(NESTED_FDNUM))
+    @test ForwardDiff.isconstant(one(NESTED_FDNUM))
+    @test ForwardDiff.isconstant(NESTED_FDNUM) == (N == 0)
+
+    @test isequal(FDNUM, Dual(PRIMAL, PARTIALS2))
+    @test isequal(PRIMAL, PRIMAL2) == isequal(FDNUM, FDNUM2)
+
+    @test isequal(NESTED_FDNUM, Dual(Dual(PRIMAL, M_PARTIALS2), NESTED_PARTIALS2))
+    @test isequal(PRIMAL, PRIMAL2) == isequal(NESTED_FDNUM, NESTED_FDNUM2)
+
+    @test FDNUM == Dual(PRIMAL, PARTIALS2)
+    @test (PRIMAL == PRIMAL2) == (FDNUM == FDNUM2)
+    @test (PRIMAL == PRIMAL2) == (NESTED_FDNUM == NESTED_FDNUM2)
+
+    @test isless(Dual(1, PARTIALS), Dual(2, PARTIALS2))
+    @test !(isless(Dual(1, PARTIALS), Dual(1, PARTIALS2)))
+    @test !(isless(Dual(2, PARTIALS), Dual(1, PARTIALS2)))
+
+    @test isless(Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS), Dual(Dual(2, M_PARTIALS2), NESTED_PARTIALS2))
+    @test !(isless(Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS), Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2)))
+    @test !(isless(Dual(Dual(2, M_PARTIALS), NESTED_PARTIALS), Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2)))
+
+    @test Dual(1, PARTIALS) < Dual(2, PARTIALS2)
+    @test !(Dual(1, PARTIALS) < Dual(1, PARTIALS2))
+    @test !(Dual(2, PARTIALS) < Dual(1, PARTIALS2))
+
+    @test Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS) < Dual(Dual(2, M_PARTIALS2), NESTED_PARTIALS2)
+    @test !(Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS) < Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2))
+    @test !(Dual(Dual(2, M_PARTIALS), NESTED_PARTIALS) < Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2))
+
+    @test Dual(1, PARTIALS) <= Dual(2, PARTIALS2)
+    @test Dual(1, PARTIALS) <= Dual(1, PARTIALS2)
+    @test !(Dual(2, PARTIALS) <= Dual(1, PARTIALS2))
+
+    @test Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS) <= Dual(Dual(2, M_PARTIALS2), NESTED_PARTIALS2)
+    @test Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS) <= Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2)
+    @test !(Dual(Dual(2, M_PARTIALS), NESTED_PARTIALS) <= Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2))
+
+    @test Dual(2, PARTIALS) > Dual(1, PARTIALS2)
+    @test !(Dual(1, PARTIALS) > Dual(1, PARTIALS2))
+    @test !(Dual(1, PARTIALS) > Dual(2, PARTIALS2))
+
+    @test Dual(Dual(2, M_PARTIALS), NESTED_PARTIALS) > Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2)
+    @test !(Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS) > Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2))
+    @test !(Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS) > Dual(Dual(2, M_PARTIALS2), NESTED_PARTIALS2))
+
+    @test Dual(2, PARTIALS) >= Dual(1, PARTIALS2)
+    @test Dual(1, PARTIALS) >= Dual(1, PARTIALS2)
+    @test !(Dual(1, PARTIALS) >= Dual(2, PARTIALS2))
+
+    @test Dual(Dual(2, M_PARTIALS), NESTED_PARTIALS) >= Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2)
+    @test Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS) >= Dual(Dual(1, M_PARTIALS2), NESTED_PARTIALS2)
+    @test !(Dual(Dual(1, M_PARTIALS), NESTED_PARTIALS) >= Dual(Dual(2, M_PARTIALS2), NESTED_PARTIALS2))
+
+    @test isnan(Dual(NaN, PARTIALS))
+    @test !(isnan(FDNUM))
+
+    @test isnan(Dual(Dual(NaN, M_PARTIALS), NESTED_PARTIALS))
+    @test !(isnan(NESTED_FDNUM))
+
+    @test isfinite(FDNUM)
+    @test !(isfinite(Dual(Inf, PARTIALS)))
+
+    @test isfinite(NESTED_FDNUM)
+    @test !(isfinite(Dual(Dual(NaN, M_PARTIALS), NESTED_PARTIALS)))
+
+    @test isinf(Dual(Inf, PARTIALS))
+    @test !(isinf(FDNUM))
+
+    @test isinf(Dual(Dual(Inf, M_PARTIALS), NESTED_PARTIALS))
+    @test !(isinf(NESTED_FDNUM))
+
+    @test isreal(FDNUM)
+    @test isreal(NESTED_FDNUM)
+
+    @test isinteger(Dual(1.0, PARTIALS))
+    @test isinteger(FDNUM) == (T == Int)
+
+    @test isinteger(Dual(Dual(1.0, M_PARTIALS), NESTED_PARTIALS))
+    @test isinteger(NESTED_FDNUM) == (T == Int)
+
+    @test iseven(Dual(2))
+    @test !(iseven(Dual(1)))
+
+    @test iseven(Dual(Dual(2)))
+    @test !(iseven(Dual(Dual(1))))
+
+    @test isodd(Dual(1))
+    @test !(isodd(Dual(2)))
+
+    @test isodd(Dual(Dual(1)))
+    @test !(isodd(Dual(Dual(2))))
+
+    ########################
+    # Promotion/Conversion #
+    ########################
+
+    const WIDE_T = widen(T)
+
+    @test promote_type(Dual{N,T}, T) == Dual{N,T}
+    @test promote_type(Dual{N,T}, WIDE_T) == Dual{N,WIDE_T}
+    @test promote_type(Dual{N,WIDE_T}, T) == Dual{N,WIDE_T}
+    @test promote_type(Dual{N,T}, Dual{N,T}) == Dual{N,T}
+    @test promote_type(Dual{N,T}, Dual{N,WIDE_T}) == Dual{N,WIDE_T}
+    @test promote_type(Dual{N,WIDE_T}, Dual{N,Dual{M,T}}) == Dual{N,Dual{M,WIDE_T}}
+
+    const WIDE_FDNUM = convert(Dual{N,WIDE_T}, FDNUM)
+    const WIDE_NESTED_FDNUM = convert(Dual{N,Dual{M,WIDE_T}}, NESTED_FDNUM)
+
+    @test typeof(WIDE_FDNUM) === Dual{N,WIDE_T}
+    @test typeof(WIDE_NESTED_FDNUM) === Dual{N,Dual{M,WIDE_T}}
+
+    @test value(WIDE_FDNUM) == PRIMAL
+    @test value(WIDE_NESTED_FDNUM) == PRIMAL
+
+    @test convert(Dual, FDNUM) === FDNUM
+    @test convert(Dual, NESTED_FDNUM) === NESTED_FDNUM
+    @test convert(Dual{N,T}, FDNUM) === FDNUM
+    @test convert(Dual{N,Dual{M,T}}, NESTED_FDNUM) === NESTED_FDNUM
+    @test convert(Dual{N,WIDE_T}, PRIMAL) === Dual(WIDE_T(PRIMAL), zero(Partials{N,WIDE_T}))
+    @test convert(Dual{N,Dual{M,WIDE_T}}, PRIMAL) === Dual(Dual(WIDE_T(PRIMAL), zero(Partials{M,WIDE_T})), zero(Partials{N,Dual{M,T}}))
+    @test convert(Dual{N,Dual{M,T}}, FDNUM) === Dual(Dual{M,T}(PRIMAL), convert(Partials{N,Dual{M,T}}, PARTIALS))
+    @test convert(Dual{N,Dual{M,WIDE_T}}, FDNUM) === Dual(Dual{M,WIDE_T}(PRIMAL), convert(Partials{N,Dual{M,WIDE_T}}, PARTIALS))
+
+    if T != Int
+        @test Base.promote_array_type(+, Dual{N,T}, T, Base.promote_op(+, Dual{N,T}, T)) == Dual{N,T}
+        @test Base.promote_array_type(+, Dual{N,Int}, T, Base.promote_op(+, Dual{N,Int}, T)) == Dual{N,T}
+        @test Base.promote_array_type(+, T, Dual{N,T}, Base.promote_op(+, T, Dual{N,T})) == Dual{N,T}
+        @test Base.promote_array_type(+, T, Dual{N,Int}, Base.promote_op(+, T, Dual{N,Int})) == Dual{N,T}
+        @test Base.promote_array_type(+, Dual{N,T}, T) == Dual{N,T}
+        @test Base.promote_array_type(+, Dual{N,Int}, T) == Dual{N,T}
+        @test Base.promote_array_type(+, T, Dual{N,T}) == Dual{N,T}
+        @test Base.promote_array_type(+, T, Dual{N,Int}) == Dual{N,T}
+    end
+
+    ########
+    # Math #
+    ########
+
+    # Arithmetic #
+    #------------#
+
+    @test FDNUM + FDNUM2 === Dual(value(FDNUM) + value(FDNUM2), partials(FDNUM) + partials(FDNUM2))
+    @test FDNUM + PRIMAL === Dual(value(FDNUM) + PRIMAL, partials(FDNUM))
+    @test PRIMAL + FDNUM === Dual(value(FDNUM) + PRIMAL, partials(FDNUM))
+
+    @test NESTED_FDNUM + NESTED_FDNUM2 === Dual(value(NESTED_FDNUM) + value(NESTED_FDNUM2), partials(NESTED_FDNUM) + partials(NESTED_FDNUM2))
+    @test NESTED_FDNUM + PRIMAL === Dual(value(NESTED_FDNUM) + PRIMAL, partials(NESTED_FDNUM))
+    @test PRIMAL + NESTED_FDNUM === Dual(value(NESTED_FDNUM) + PRIMAL, partials(NESTED_FDNUM))
+
+    @test FDNUM - FDNUM2 === Dual(value(FDNUM) - value(FDNUM2), partials(FDNUM) - partials(FDNUM2))
+    @test FDNUM - PRIMAL === Dual(value(FDNUM) - PRIMAL, partials(FDNUM))
+    @test PRIMAL - FDNUM === Dual(PRIMAL - value(FDNUM), -(partials(FDNUM)))
+    @test -(FDNUM) === Dual(-(value(FDNUM)), -(partials(FDNUM)))
+
+    @test NESTED_FDNUM - NESTED_FDNUM2 === Dual(value(NESTED_FDNUM) - value(NESTED_FDNUM2), partials(NESTED_FDNUM) - partials(NESTED_FDNUM2))
+    @test NESTED_FDNUM - PRIMAL === Dual(value(NESTED_FDNUM) - PRIMAL, partials(NESTED_FDNUM))
+    @test PRIMAL - NESTED_FDNUM === Dual(PRIMAL - value(NESTED_FDNUM), -(partials(NESTED_FDNUM)))
+    @test -(NESTED_FDNUM) === Dual(-(value(NESTED_FDNUM)), -(partials(NESTED_FDNUM)))
+
+    @test FDNUM * FDNUM2 === Dual(value(FDNUM) * value(FDNUM2), ForwardDiff._mul_partials(partials(FDNUM), partials(FDNUM2), value(FDNUM2), value(FDNUM)))
+    @test FDNUM * PRIMAL === Dual(value(FDNUM) * PRIMAL, partials(FDNUM) * PRIMAL)
+    @test PRIMAL * FDNUM === Dual(value(FDNUM) * PRIMAL, partials(FDNUM) * PRIMAL)
+
+    @test NESTED_FDNUM * NESTED_FDNUM2 === Dual(value(NESTED_FDNUM) * value(NESTED_FDNUM2), ForwardDiff._mul_partials(partials(NESTED_FDNUM), partials(NESTED_FDNUM2), value(NESTED_FDNUM2), value(NESTED_FDNUM)))
+    @test NESTED_FDNUM * PRIMAL === Dual(value(NESTED_FDNUM) * PRIMAL, partials(NESTED_FDNUM) * PRIMAL)
+    @test PRIMAL * NESTED_FDNUM === Dual(value(NESTED_FDNUM) * PRIMAL, partials(NESTED_FDNUM) * PRIMAL)
+
+    if M > 0 && N > 0
+        @test Dual(FDNUM) / Dual(PRIMAL) === Dual(FDNUM / PRIMAL)
+        @test Dual(PRIMAL) / Dual(FDNUM) === Dual(PRIMAL / FDNUM)
+        @test Dual(FDNUM) / FDNUM2 === FDNUM / FDNUM2
+        @test FDNUM / Dual(FDNUM2) === FDNUM / FDNUM2
+        @test Dual(FDNUM, FDNUM2) / Dual(PRIMAL) === Dual(FDNUM, FDNUM2) / PRIMAL
+        @test Dual(PRIMAL) / Dual(FDNUM, FDNUM2) === PRIMAL / Dual(FDNUM, FDNUM2)
+    end
+
+    test_approx_diffnums(FDNUM / FDNUM2, Dual(value(FDNUM) / value(FDNUM2), ForwardDiff._div_partials(partials(FDNUM), partials(FDNUM2), value(FDNUM), value(FDNUM2))))
+    test_approx_diffnums(FDNUM / PRIMAL, Dual(value(FDNUM) / PRIMAL, partials(FDNUM) / PRIMAL))
+    test_approx_diffnums(PRIMAL / FDNUM, Dual(PRIMAL / value(FDNUM), (-(PRIMAL) / value(FDNUM)^2) * partials(FDNUM)))
+
+    test_approx_diffnums(NESTED_FDNUM / NESTED_FDNUM2, Dual(value(NESTED_FDNUM) / value(NESTED_FDNUM2), ForwardDiff._div_partials(partials(NESTED_FDNUM), partials(NESTED_FDNUM2), value(NESTED_FDNUM), value(NESTED_FDNUM2))))
+    test_approx_diffnums(NESTED_FDNUM / PRIMAL, Dual(value(NESTED_FDNUM) / PRIMAL, partials(NESTED_FDNUM) / PRIMAL))
+    test_approx_diffnums(PRIMAL / NESTED_FDNUM, Dual(PRIMAL / value(NESTED_FDNUM), (-(PRIMAL) / value(NESTED_FDNUM)^2) * partials(NESTED_FDNUM)))
+
+    test_approx_diffnums(FDNUM^FDNUM2, exp(FDNUM2 * log(FDNUM)))
+    test_approx_diffnums(FDNUM^PRIMAL, exp(PRIMAL * log(FDNUM)))
+    test_approx_diffnums(PRIMAL^FDNUM, exp(FDNUM * log(PRIMAL)))
+
+    test_approx_diffnums(NESTED_FDNUM^NESTED_FDNUM2, exp(NESTED_FDNUM2 * log(NESTED_FDNUM)))
+    test_approx_diffnums(NESTED_FDNUM^PRIMAL, exp(PRIMAL * log(NESTED_FDNUM)))
+    test_approx_diffnums(PRIMAL^NESTED_FDNUM, exp(NESTED_FDNUM * log(PRIMAL)))
+
+    @test partials(NaNMath.pow(Dual(-2.0, 1.0), Dual(2.0, 0.0)), 1) == -4.0
+
+    # Unary Functions #
+    #-----------------#
+
+    @test conj(FDNUM) === FDNUM
+    @test conj(NESTED_FDNUM) === NESTED_FDNUM
+    @test transpose(FDNUM) === FDNUM
+    @test transpose(NESTED_FDNUM) === NESTED_FDNUM
+    @test ctranspose(FDNUM) === FDNUM
+    @test ctranspose(NESTED_FDNUM) === NESTED_FDNUM
+
+    @test abs(-FDNUM) === FDNUM
+    @test abs(FDNUM) === FDNUM
+    @test abs(-NESTED_FDNUM) === NESTED_FDNUM
+    @test abs(NESTED_FDNUM) === NESTED_FDNUM
+
+    if T != Int
+        UNSUPPORTED_NESTED_FUNCS = (:trigamma, :airyprime, :besselj1, :bessely1)
+        DOMAIN_ERR_FUNCS = (:asec, :acsc, :asecd, :acscd, :acoth, :acosh)
+
+        for fsym in ForwardDiff.AUTO_DEFINED_UNARY_FUNCS
+            try
+                v = :v
+                deriv = Calculus.differentiate(:($(fsym)($v)), v)
+                is_domain_err_func = fsym in DOMAIN_ERR_FUNCS
+                is_nanmath_func = fsym in ForwardDiff.NANMATH_FUNCS
+                is_unsupported_nested_func = fsym in UNSUPPORTED_NESTED_FUNCS
+                @eval begin
+                    fdnum = $(is_domain_err_func ? FDNUM + 1 : FDNUM)
+                    $(v) = ForwardDiff.value(fdnum)
+                    $(test_approx_diffnums)($(fsym)(fdnum), ForwardDiff.Dual($(fsym)($v), $(deriv) * ForwardDiff.partials(fdnum)))
+                    if $(is_nanmath_func)
+                        $(test_approx_diffnums)(NaNMath.$(fsym)(fdnum), ForwardDiff.Dual(NaNMath.$(fsym)($v), $(deriv) * ForwardDiff.partials(fdnum)))
+                    end
+
+                    if $(!(is_unsupported_nested_func))
+                        nested_fdnum = $(is_domain_err_func ? NESTED_FDNUM + 1 : NESTED_FDNUM)
+                        $(v) = ForwardDiff.value(nested_fdnum)
+                        $(test_approx_diffnums)($(fsym)(nested_fdnum), ForwardDiff.Dual($(fsym)($v), $(deriv) * ForwardDiff.partials(nested_fdnum)))
+                        if $(is_nanmath_func)
+                            $(test_approx_diffnums)(NaNMath.$(fsym)(nested_fdnum), ForwardDiff.Dual(NaNMath.$(fsym)($v), $(deriv) * ForwardDiff.partials(nested_fdnum)))
+                        end
+                    end
+                end
+            catch err
+                warn("Encountered error when testing $(fsym)(::Dual):")
+                throw(err)
+            end
+        end
+    end
+
+    # Manually Optimized Functions #
+    #------------------------------#
+
+    test_approx_diffnums(hypot(FDNUM, FDNUM2), sqrt(FDNUM^2 + FDNUM2^2))
+    test_approx_diffnums(hypot(FDNUM, FDNUM2, FDNUM), sqrt(2*(FDNUM^2) + FDNUM2^2))
+    map(test_approx_diffnums, ForwardDiff.sincos(FDNUM), (sin(FDNUM), cos(FDNUM)))
+
+    if T === Float32
+        @test typeof(sqrt(FDNUM)) === typeof(FDNUM)
+        @test typeof(sqrt(NESTED_FDNUM)) === typeof(NESTED_FDNUM)
+    end
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,3 @@
 using DualNumbers, Base.Test
 
-if VERSION >= v"0.5.0-dev+5429"
-    @test checkindex(Bool, 1:3, dual(2))
-end
-
-# wrap in individual modules to avoid name conflicts.
-module TestAutomaticDifferentiation
-include("automatic_differentiation_test.jl")
-end
+include("DualTest.jl")


### PR DESCRIPTION
Well, I looked at https://github.com/JuliaDiff/DualNumbers.jl/issues/45, so I thought this PR might help. The code is basically the same, but I exported `Dual`, `value` and `partials`. I also added pretty printing, so Dual Numbers would look like: 
```julia
julia> d = Dual(4, 1, 3)
4 + 1ϵ₁ + 3ϵ₂
```