### PR TITLE
Updates for Julia 0.6 and 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
-Compat 0.9.1
+julia 0.6
+Compat 0.49.0
 Calculus
 NaNMath

--- a/src/DualNumbers.jl
+++ b/src/DualNumbers.jl
@@ -1,19 +1,16 @@
 __precompile__()
 
 module DualNumbers
-  importall Base
 
-  import NaNMath
-  import Calculus
-  using Compat
+using Compat
+import NaNMath
+import Calculus
 
-  include("dual.jl")
+include("dual.jl")
 
-  Base.@deprecate_binding du ɛ
-  @deprecate inf{T}(::Type{Dual{T}}) convert(Dual{T}, Inf)
-  @deprecate nan{T}(::Type{Dual{T}}) convert(Dual{T}, NaN)
+Base.@deprecate_binding du ɛ
 
-  export
+export
     Dual,
     Dual128,
     Dual64,
@@ -32,4 +29,5 @@ module DualNumbers
     abs2dual,
     ɛ,
     imɛ
-end
+
+end # module

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -1,7 +1,9 @@
-using DualNumbers, Base.Test
+using DualNumbers
+using Compat
+using Compat.Test
+using Compat.LinearAlgebra
 import DualNumbers: value
 import NaNMath
-using Compat
 
 x = Dual(2, 1)
 y = x^3
@@ -30,7 +32,7 @@ y = 1/x
 @test epsilon(y) ≈ -1/2^2
 
 Q = [1.0 0.1; 0.1 1.0]
-x = @compat dual.([1.0,2.0])
+x = dual.([1.0,2.0])
 x[1] = Dual(1.0,1.0)
 y = (1/2)*dot(x,Q*x)
 @test value(y) ≈ 2.7
@@ -120,11 +122,11 @@ z = Dual(1.0+1.0im,cis(π/2))
 @test abs(z) ≡ sqrt(2) + 1/sqrt(2)*ɛ
 
 # tests vectorized methods
-const zv = @compat dual.(collect(1.0:10.0), ones(10))
+const zv = dual.(collect(1.0:10.0), ones(10))
 
-f = @compat exp.(zv)
-@test all(@compat value.(f) .== exp.(value.(zv)))
-@test all(@compat epsilon.(f) .== epsilon.(zv) .* exp.(value.(zv)))
+f = exp.(zv)
+@test all(value.(f) .== exp.(value.(zv)))
+@test all(epsilon.(f) .== epsilon.(zv) .* exp.(value.(zv)))
 
 # tests norms and inequalities
 @test norm(f,Inf) ≤ norm(f) ≤ norm(f,1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
-using DualNumbers, Base.Test
+using DualNumbers
+using Compat
+using Compat.Test
 
-if VERSION >= v"0.5.0-dev+5429"
-    @test checkindex(Bool, 1:3, dual(2))
-end
+@test checkindex(Bool, 1:3, dual(2))
 
 # wrap in individual modules to avoid name conflicts.
 module TestAutomaticDifferentiation


### PR DESCRIPTION
This raises the minimum required Julia version to 0.6 and provides fixes for deprecations and changes in Julia 0.7.