### PR TITLE
Remove unused Compat dependency

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.7
-Compat 0.49.0
 Calculus
 NaNMath
 SpecialFunctions 0.7

--- a/src/DualNumbers.jl
+++ b/src/DualNumbers.jl
@@ -1,6 +1,6 @@
 module DualNumbers
 
-using Compat, SpecialFunctions
+using SpecialFunctions
 import NaNMath
 import Calculus
 

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -1,7 +1,6 @@
 using DualNumbers, SpecialFunctions
-using Compat
 using Test
-using Compat.LinearAlgebra
+using LinearAlgebra
 import DualNumbers: value
 import NaNMath
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using DualNumbers
-using Compat
 using Test
 
 @test checkindex(Bool, 1:3, dual(2))


### PR DESCRIPTION
We require Julia 0.7, so this is unnecessary.