### PR TITLE
Dual raised to power UInt64(0) gives NaN dualpart

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DualNumbers"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -261,6 +261,7 @@ end
 Base.mod(z::Dual, n::Number) = Dual(mod(value(z), n), epsilon(z))
 
 # these two definitions are needed to fix ambiguity warnings
+Base.:^(z::Dual, n::Unsigned) = z^Signed(n)
 Base.:^(z::Dual, n::Integer) = Dual(value(z)^n, epsilon(z)*n*value(z)^(n-1))
 Base.:^(z::Dual, n::Rational) = Dual(value(z)^n, epsilon(z)*n*value(z)^(n-1))
 

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -15,6 +15,9 @@ y = x^3.0
 @test value(y) ≈ 2.0^3
 @test epsilon(y) ≈ 3.0*2^2
 
+y = Dual(2.0, 1)^UInt64(0)
+@test !isnan(epsilon(y))
+
 y = sin(x)+exp(x)
 @test value(y) ≈ sin(2)+exp(2)
 @test epsilon(y) ≈ cos(2)+exp(2)


### PR DESCRIPTION
As it stands with `[fa6b7ba4] DualNumbers v0.6.3`, I get this behaviour:

```julia
julia> using DualNumbers

julia> Dual(2.0, 1)^UInt64(0)
Dual{Float64}(1.0,NaN)
```

This PR provides a little fix.