### PR TITLE
Using a strong zero in Dual(0.0, 1)^0 to avoid NaN

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DualNumbers"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DualNumbers"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -261,6 +261,7 @@ end
 Base.mod(z::Dual, n::Number) = Dual(mod(value(z), n), epsilon(z))
 
 # these two definitions are needed to fix ambiguity warnings
+Base.:^(z::Dual, n::Unsigned) = z^Signed(n)
 Base.:^(z::Dual, n::Integer) = Dual(value(z)^n, epsilon(z)*n*value(z)^(n-1))
 Base.:^(z::Dual, n::Rational) = Dual(value(z)^n, epsilon(z)*n*value(z)^(n-1))
 

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -268,6 +268,7 @@ function pow(z::Dual, n::AbstractFloat)
 end
 function pow(z::Dual{T}, n::Integer) where T
     iszero(n) && return Dual(one(T), zero(T)) # avoid DomainError Int^(negative Int)
+    isone(z) && return Dual(one(T), epsilon(z) * n)
     return Dual(value(z)^n, epsilon(z) * n * value(z)^(n - 1))
 end
 # these first two definitions are needed to fix ambiguity warnings

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -15,6 +15,9 @@ y = x^3.0
 @test value(y) ≈ 2.0^3
 @test epsilon(y) ≈ 3.0*2^2
 
+y = Dual(2.0, 1)^UInt64(0)
+@test !isnan(epsilon(y))
+
 y = sin(x)+exp(x)
 @test value(y) ≈ sin(2)+exp(2)
 @test epsilon(y) ≈ cos(2)+exp(2)

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -40,6 +40,9 @@ powwrap(z, n, epspart=0) = Dual(z, epspart)^n
 # these ones don't DomainError
 @test powwrap(0, 0, 0) == Dual(1, 0) # special case is handled
 @test powwrap(0, 0, 1) == Dual(1, 0) # special case is handled
+@test powwrap(1, -1) == powwrap(1.0, -1) # special case is handled
+@test powwrap(1, -2) == powwrap(1.0, -2) # special case is handled
+@test powwrap(1, -123) == powwrap(1.0, -123) # special case is handled
 @test powwrap(1, 0) == Dual(1, 1)
 @test powwrap(123, 0) == Dual(1, 1)
 for i ∈ -3:3

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -15,6 +15,29 @@ y = x^3.0
 @test value(y) ≈ 2.0^3
 @test epsilon(y) ≈ 3.0*2^2
 
+# taking care with divides by zero where there shouldn't be any on paper
+for (y, n) ∈ Iterators.product((float(x), Dual(0.0, 1)), (0, 0.0))
+  z = y^n
+  @test value(z) == 1
+  @test !isnan(epsilon(z))
+  @test epsilon(z) == 0
+end
+
+# acting on floats works as expected
+for (y, n) ∈ ((float(x), Dual(0.0, 1)), -1:1)
+  @test float(x)^n == float(x)^float(n)
+end
+
+# power_by_squaring error for integers
+powwrap(z, n) = Dual(z, 1)^n # needs to be wrapped to make n a literal
+@test_throws DomainError powwrap(123, 0)
+@test_throws DomainError powwrap(2, -1)
+@test_throws DomainError powwrap(123, -1)
+# this one doesn't error!
+@test powwrap(1, -1) == Dual(1, -1)
+
+@test !isnan(epsilon(Dual(0, 1)^1))
+
 y = Dual(2.0, 1)^UInt64(0)
 @test !isnan(epsilon(y))
 


### PR DESCRIPTION
I found another minor bug-ette:

```
julia> Dual(0.0, 1)^0
Dual{Float64}(1.0,NaN)
```

The behaviour from this PR gives:

```
julia> Dual(0.0, 1)^0
1.0 - 0.0ɛ
```

What do you reckon?