### PR TITLE
Implement complex(::Type{<:Dual})

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -179,6 +179,7 @@ Base.hash(z::Dual) = (x = hash(value(z)); epsilon(z)==0 ? x : bitmix(x,hash(epsi
 
 Base.float(z::Union{Dual{T}, Dual{Complex{T}}}) where {T<:AbstractFloat} = z
 Base.complex(z::Dual{<:Complex}) = z
+Base.complex(::Type{Dual{R}}) where {R} = Dual{Complex{R}}
 
 Base.floor(z::Dual) = floor(value(z))
 Base.ceil(z::Dual)  = ceil(value(z))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,3 +9,9 @@ using Test
 module TestAutomaticDifferentiation
 include("automatic_differentiation_test.jl")
 end
+
+@testset "complex" begin
+    for D in [Dual32, Dual64, Dual128]
+        @test typeof(complex(zero(D))) == complex(D)
+    end
+end


### PR DESCRIPTION
This matches the docstring of `complex`, so now

```julia
julia> typeof(complex(zero(Dual128))) == complex(Dual128)
true
```