### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 Calculus = "0.5"
 NaNMath = "0.3"
-SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0"
+SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0, 2"
 julia = "0.7, 1.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DualNumbers"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.