### PR TITLE
Implement `complex` for dual arguments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DualNumbers"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -44,6 +44,7 @@ function Base.complex(x::Dual, y::Dual)
 end
 Base.complex(x::Real, y::Dual) = complex(dual(x), y)
 Base.complex(x::Dual, y::Real) = complex(x, dual(y))
+Base.complex(::Type{Dual{T}}) where {T} = Dual{complex(T)}
 
 const realpart = value
 const dualpart = epsilon

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -39,6 +39,12 @@ dual(x::ReComp, y::ReComp) = Dual(x, y)
 dual(x::ReComp) = Dual(x)
 dual(z::Dual) = z
 
+function Base.complex(x::Dual, y::Dual)
+    dual(complex(value(x), value(y)), complex(epsilon(x), epsilon(y)))
+end
+Base.complex(x::Real, y::Dual) = complex(dual(x), y)
+Base.complex(x::Dual, y::Real) = complex(x, dual(y))
+
 const realpart = value
 const dualpart = epsilon
 

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -200,6 +200,13 @@ test(x, y) = x^2 + y
 @test epsilon(Dual(-2.0,1.0)^Dual(2.0,0.0)) == -4
 
 
+# test complex and dual mixing
+@test complex(dual(1, 2), dual(3, 4)) == dual(complex(1, 3), complex(2, 4))
+@test complex(1, dual(2, 3)) == dual(complex(1, 2), complex(0, 3))
+@test complex(dual(1, 2), 3) == dual(complex(1, 3), complex(2, 0))
+@test complex(dual(1, 2)) == dual(complex(1, 0), complex(2, 0))
+
+
 # test for flipsign
 flipsign(Dual(1.0,1.0),2.0) == Dual(1.0,1.0)
 flipsign(Dual(1.0,1.0),-2.0) == Dual(-1.0,-1.0)

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -205,7 +205,8 @@ test(x, y) = x^2 + y
 @test complex(1, dual(2, 3)) == dual(complex(1, 2), complex(0, 3))
 @test complex(dual(1, 2), 3) == dual(complex(1, 3), complex(2, 0))
 @test complex(dual(1, 2)) == dual(complex(1, 0), complex(2, 0))
-
+@test complex(Dual128) === DualComplex256
+@test complex(Dual64) === DualComplex128
 
 # test for flipsign
 flipsign(Dual(1.0,1.0),2.0) == Dual(1.0,1.0)


### PR DESCRIPTION
This PR implements the following methods:
- `complex(::Dual, ::Real) -> Dual{<:Complex}`
- `complex(::Real, ::Dual) -> Dual{<:Complex}`
- `complex(::Dual, ::Dual) -> Dual{<:Complex}`
- `complex(::Type{Dual{T}})`

This allows `Dual` to be used for automatically differentiating not just the complex functions for which rules are defined here but also the construction of those complex numbers.