### PR TITLE
Implement 2-arg atan

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DualNumbers"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DualNumbers"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -345,7 +345,7 @@ function Base.atan(y::Dual, x::Real)
 end
 function Base.atan(y::Real, x::Dual)
     u = value(x)^2 + y^2
-    return Dual(atan(y, value(x)), (y/u) * epsilon(x))
+    return Dual(atan(y, value(x)), (y/u) * -epsilon(x))
 end
 
 Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Dual) = checkindex(Bool, inds, value(i))

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -335,4 +335,17 @@ Base.exp10(x::Dual) = (y = exp10(value(x)); Dual(y, y * log(10) * epsilon(x)))
 Base.sinpi(z::Dual) = Dual(sinpi(value(z)),epsilon(z)*cospi(value(z))*π)
 Base.cospi(z::Dual) = Dual(cospi(value(z)),-epsilon(z)*sinpi(value(z))*π)
 
+function Base.atan(y::Dual, x::Dual)
+    u = value(x)^2 + value(y)^2
+    return dual(atan(value(y), value(x)), (value(x)/u) * epsilon(y) - (value(y)/u) * epsilon(x))
+end
+function Base.atan(y::Dual, x::Real)
+    u = x^2 + value(y)^2
+    return Dual(atan(value(y), x), (x/u) * epsilon(y))
+end
+function Base.atan(y::Real, x::Dual)
+    u = value(x)^2 + y^2
+    return Dual(atan(y, value(x)), (y/u) * epsilon(x))
+end
+
 Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Dual) = checkindex(Bool, inds, value(i))

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -95,6 +95,14 @@ function squareroot(x)
     return it
 end
 
+@testset "atan consistency" begin
+    x = dual(randn(2)...)
+    y = dual(randn(2)...)
+    @test value(atan(y, x)) ≈ atan(value(y), value(x))
+    @test value(atan(y / x)) ≈ atan(value(y) / value(x))
+    @test epsilon(atan(y, x)) ≈ epsilon(atan(y / x))
+end
+
 @test epsilon(squareroot(Dual(10000.0,1.0))) ≈ 0.005
 
 @test epsilon(exp(1)^Dual(1.0,1.0)) ≈ exp(1)

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -101,6 +101,11 @@ end
     @test value(atan(y, x)) ≈ atan(value(y), value(x))
     @test value(atan(y / x)) ≈ atan(value(y) / value(x))
     @test epsilon(atan(y, x)) ≈ epsilon(atan(y / x))
+
+    @test value(atan(y, value(x))) ≈ atan(value(y), value(x))
+    @test epsilon(atan(y, value(x))) ≈ epsilon(atan(y, dual(value(x))))
+    @test value(atan(value(y), x)) ≈ atan(value(y), value(x))
+    @test epsilon(atan(value(y), x)) ≈ epsilon(atan(dual(value(y)), x))
 end
 
 @test epsilon(squareroot(Dual(10000.0,1.0))) ≈ 0.005


### PR DESCRIPTION
This PR implements 2-argument `atan`:
- `atan(::Dual, ::Dual)`
- `atan(::Dual, ::Real)`
- `atan(::Real, ::Dual)`