### PR TITLE
Fix InexactError call in convert

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DualNumbers"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -21,7 +21,7 @@ const DualComplex64  = Dual{ComplexF16}
 Base.convert(::Type{Dual{T}}, z::Dual{T}) where {T<:ReComp} = z
 Base.convert(::Type{Dual{T}}, z::Dual) where {T<:ReComp} = Dual{T}(convert(T, value(z)), convert(T, epsilon(z)))
 Base.convert(::Type{Dual{T}}, x::Number) where {T<:ReComp} = Dual{T}(convert(T, x), convert(T, 0))
-Base.convert(::Type{T}, z::Dual) where {T<:ReComp} = (epsilon(z)==0 ? convert(T, value(z)) : throw(InexactError()))
+Base.convert(::Type{T}, z::Dual) where {T<:ReComp} = (epsilon(z)==0 ? convert(T, value(z)) : throw(InexactError(:convert, T, z)))
 
 Base.promote_rule(::Type{Dual{T}}, ::Type{Dual{S}}) where {T<:ReComp,S<:ReComp} = Dual{promote_type(T, S)}
 Base.promote_rule(::Type{Dual{T}}, ::Type{S}) where {T<:ReComp,S<:ReComp} = Dual{promote_type(T, S)}

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -241,3 +241,5 @@ end
 
 @test value(3) == 3
 @test epsilon(44.0) ≈ 0.0
+
+@test_throws InexactError convert(Float64, Dual(1,1))


### PR DESCRIPTION
On master:
```julia
julia> convert(Float64, Dual(1,1))
ERROR: MethodError: no method matching InexactError()
```
After this
```julia
julia> convert(Float64, Dual(1,1))
ERROR: InexactError: convert(Float64, 1 + 1ɛ)
```