### PR TITLE
Fix definitions of `==` and `isless`

### DIFF
--- a/src/dual.jl
+++ b/src/dual.jl
@@ -170,17 +170,17 @@ end
 Base.convert(::Type{Dual}, z::Dual) = z
 Base.convert(::Type{Dual}, x::Number) = Dual(x)
 
-Base.:(==)(z::Dual, w::Dual) = value(z) == value(w)
-Base.:(==)(z::Dual, x::Number) = value(z) == x
-Base.:(==)(x::Number, z::Dual) = value(z) == x
+Base.:(==)(z::Dual, w::Dual) = value(z) == value(w) && epsilon(z) == epsilon(w)
+Base.:(==)(z::Dual, x::Number) = value(z) == x && iszero(epsilon(z))
+Base.:(==)(x::Number, z::Dual) = z == x
 
 Base.isequal(z::Dual, w::Dual) = isequal(value(z),value(w)) && isequal(epsilon(z), epsilon(w))
 Base.isequal(z::Dual, x::Number) = isequal(value(z), x) && isequal(epsilon(z), zero(x))
 Base.isequal(x::Number, z::Dual) = isequal(z, x)
 
-Base.isless(z::Dual{<:Real},w::Dual{<:Real}) = value(z) < value(w)
-Base.isless(z::Real,w::Dual{<:Real}) = z < value(w)
-Base.isless(z::Dual{<:Real},w::Real) = value(z) < w
+Base.isless(z::Dual{<:Real},w::Dual{<:Real}) = isless(value(z), value(w)) || (isequal(value(z), value(w)) && isless(epsilon(z), epsilon(w)))
+Base.isless(z::Real,w::Dual{<:Real}) = isless(z, value(w)) || (isequal(z, value(w)) && isless(zero(epsilon(w)), epsilon(w)))
+Base.isless(z::Dual{<:Real},w::Real) = isless(value(z), w) || (isequal(value(z), w) && isless(epsilon(z), zero(epsilon(z))))
 
 Base.hash(z::Dual) = (x = hash(value(z)); epsilon(z)==0 ? x : bitmix(x,hash(epsilon(z))))
 

--- a/test/automatic_differentiation_test.jl
+++ b/test/automatic_differentiation_test.jl
@@ -43,20 +43,26 @@ powwrap(z, n, epspart=0) = Dual(z, epspart)^n
 @test powwrap(1, -1) == powwrap(1.0, -1) # special case is handled
 @test powwrap(1, -2) == powwrap(1.0, -2) # special case is handled
 @test powwrap(1, -123) == powwrap(1.0, -123) # special case is handled
-@test powwrap(1, 0) == Dual(1, 1)
-@test powwrap(123, 0) == Dual(1, 1)
+@test powwrap(1, 0) == Dual(1, 0)
+@test powwrap(1, 0) != Dual(1, 1)
+@test powwrap(123, 0) == Dual(1, 0)
+@test powwrap(123, 0) != Dual(1, 1)
 for i ∈ -3:3
-  @test powwrap(1, i) == Dual(1, i)
+  @test powwrap(1, i) == Dual(1, 0)
+  @test i == 0 || (powwrap(1, i) != Dual(1, i))
 end
 
 # this no longer throws 1/0 DomainError
-@test powwrap(0, Dual(0, 1)) == Dual(1, 0)
+@test powwrap(0, Dual(0, 1)) == Dual(1, -Inf)
+@test powwrap(0, Dual(0, 1)) != Dual(1, 0)
 # this never did DomainError because it starts off with a float
-@test 0.0^Dual(0, 1) == Dual(1.0, NaN)
+@test 0.0^Dual(0, 1) == Dual(1.0, -Inf)
+@test 0.0^Dual(0, 1) != Dual(1.0, NaN)
 # and Dual^Dual uses a log and is now type stable
 # because the log promotes ints to floats for all values
 @test typeof(value(powwrap(0, Dual(0, 1)))) == Float64
-@test Dual(0, 1)^Dual(0, 1) == Dual(1, 0)
+@test Dual(0, 1)^Dual(0, 1) == Dual(1, -Inf)
+@test Dual(0, 1)^Dual(0, 1) != Dual(1, 0)
 
 y = Dual(2.0, 1)^UInt64(0)
 @test !isnan(epsilon(y))


### PR DESCRIPTION
Given the [definitions of `==` and `isequal` in ForwardDiff#master](https://github.com/JuliaDiff/ForwardDiff.jl/blob/cbb2733e9941a91862f137aa49cc47aca1761cff/src/dual.jl#L400-L409), the PR reverts https://github.com/JuliaDiff/DualNumbers.jl/commit/337539f32622b8d713a7ea122aeaafb4f1e0de3b (see #10) and defines both `==(x, y)` and `isequal(x, y)` in terms of both `value(x)` and `epsilon(x)` etc. This makes
- the definitions in ForwardDiff and DualNumbers consistent,
- the definitions of `==` and `isequal` in DualNumbers consistent,
- the definitions of `==` and `isequal` mathematically correct.

Additionally, the PR fixes `isless`: According to its docstring, `isless(x, y)` should
```markdown
Test whether `x` is less than `y`, according to a fixed total order (defined together with `isequal`). `isless` is not defined for pairs `(x, y)` of all types. However, if it is defined, it is expected to satisfy the following:
- If `isless(x, y)` is defined, then so is `isless(y, x)` and `isequal(x, y)`, and exactly one of those three yields true.
- The relation defined by `isless` is transitive, i.e., `isless(x, y)` && `isless(y, z)` implies `isless(x, z)`.
```
On the master branch, however, the first requirement is not satisfied (e.g., choose `x = dual(3, 0.5)` and `y = dual(3, 1.0)`: then neither `isless(x, y)`, `isless(y, x)`, nor `isequal(x, y)` is satisfied).

cc @andreasnoack who was involved in #10